### PR TITLE
Add support for CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,9 @@ For example, to set the `--wifi --passcode 1234` flags:
 snap set matter-pi-gpio-commander args="--wifi --passcode 1234"
 ```
 
-To see the list of all flag, run the following command;
-```bash
-matter-pi-gpio-commander.lighting-help
+To see the list of all flags, run the `lighting-help` app:
 ```
-```
+$ matter-pi-gpio-commander.lighting-help
 Usage: /snap/matter-pi-gpio-commander/x3/bin/lighting-app [opti
 
 GENERAL OPTIONS

--- a/README.md
+++ b/README.md
@@ -25,6 +25,38 @@ Refer to [GPIO.md](GPIO.md) for details.
 sudo snap set matter-pi-gpio-commander wiringpi-pin=7
 ```
 
+Make sure to also [grant the GPIO access](#GPIO).
+
+#### Set CLI flags
+The lighting app runs as a service without any default CLI flags. The snap allows passing flags to the service via the `args` snap option. 
+
+For example, to set the `--wifi --passcode 1234` flags:
+```
+snap set matter-pi-gpio-commander args="--wifi --passcode 1234"
+```
+
+To see the list of all flag, run the following command;
+```bash
+matter-pi-gpio-commander.lighting-help
+```
+```
+Usage: /snap/matter-pi-gpio-commander/x3/bin/lighting-app [opti
+
+GENERAL OPTIONS
+
+  --ble-device <number>
+       The device number for CHIPoBLE, without 'hci' prefix, can be found by hciconfig.
+
+  --wifi
+       Enable WiFi management via wpa_supplicant.
+
+  --thread
+       Enable Thread management via ot-agent.
+
+  ...
+```
+
+
 ### Grant access
 The snap uses [interfaces](https://snapcraft.io/docs/interface-management) to allow access to external resources. Depending on the use case, you need to "connect" certain interfaces to grant the necessary access.
 #### DNS-SD

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ For example, to set the `--wifi --passcode 1234` flags:
 snap set matter-pi-gpio-commander args="--wifi --passcode 1234"
 ```
 
-To see the list of all flags, run the `lighting-help` app:
+To see the list of all flags, run the `help` app:
 ```
-$ matter-pi-gpio-commander.lighting-help
+$ matter-pi-gpio-commander.help
 Usage: /snap/matter-pi-gpio-commander/x3/bin/lighting-app [opti
 
 GENERAL OPTIONS

--- a/README.md
+++ b/README.md
@@ -28,14 +28,16 @@ sudo snap set matter-pi-gpio-commander wiringpi-pin=7
 Make sure to also [grant the GPIO access](#GPIO).
 
 #### Set CLI flags
-The lighting app runs as a service without any default CLI flags. The snap allows passing flags to the service via the `args` snap option. 
+By default, the lighting app runs as a service without any CLI flags.
+The snap allows passing flags to the service via the `args` snap option. 
+This is useful for overriding SDK defaults to customize the application behavior.
 
 For example, to set the `--wifi --passcode 1234` flags:
 ```
 snap set matter-pi-gpio-commander args="--wifi --passcode 1234"
 ```
 
-To see the list of all flags, run the `help` app:
+To see the list of all flags and SDK default, run the `help` app:
 ```
 $ matter-pi-gpio-commander.help
 Usage: /snap/matter-pi-gpio-commander/x3/bin/lighting-app [opti

--- a/snap/local/bin/load-snap-options.sh
+++ b/snap/local/bin/load-snap-options.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -e
 
 export WIRINGPI_PIN=$(snapctl get wiringpi-pin)
+export ARGS=$(snapctl get args)
 
 exec "$@"

--- a/snap/local/bin/run.sh
+++ b/snap/local/bin/run.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
-$SNAP/bin/lighting-app
+$SNAP/bin/lighting-app $ARGS

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: matter-pi-gpio-commander
-version: "0.2"
+version: "0.3.0"
 summary: Raspberry Pi GPIO as a Matter lighting app
 description: Refer to https://snapcraft.io/matter-pi-gpio-commander
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -131,7 +131,9 @@ apps:
       - bluez
       - avahi-control
       - gpio
-  
+  lighting-help:
+    command: bin/lighting-app -h
+
   # This app is to test the GPIO control without using a Matter controller
   test-blink:
     command-chain:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -131,7 +131,7 @@ apps:
       - bluez
       - avahi-control
       - gpio
-  lighting-help:
+  help:
     command: bin/lighting-app -h
 
   # This app is to test the GPIO control without using a Matter controller


### PR DESCRIPTION
The application using the C++ takes arguments such as:
- --wifi
- --thread
- --ble-device=N

Here is the help output of the app:
```
$ /snap/matter-pi-gpio-commander/current/bin/lighting-app -h
Usage: /snap/matter-pi-gpio-commander/current/bin/lighting-app 

GENERAL OPTIONS

  --ble-device <number>
       The device number for CHIPoBLE, without 'hci' prefix, can be found by hciconfig.

  --wifi
       Enable WiFi management via wpa_supplicant.

  --thread
       Enable Thread management via ot-agent.

  --version <version>
       The version indication provides versioning of the setup payload.

  --vendor-id <id>
       The Vendor ID is assigned by the Connectivity Standards Alliance.

  --product-id <id>
       The Product ID is specified by vendor.

  --custom-flow <Standard = 0 | UserActionRequired = 1 | Custom = 2>
       A 2-bit unsigned enumeration specifying manufacturer-specific custom flow options.

  --capabilities <None = 0, SoftAP = 1 << 0, BLE = 1 << 1, OnNetwork = 1 << 2>
       Discovery Capabilities Bitmask which contains information about Device’s available technologies for device discovery.

  --discriminator <discriminator>
       A 12-bit unsigned integer match the value which a device advertises during commissioning.

  --passcode <passcode>
       A 27-bit unsigned integer, which serves as proof of possession during commissioning. 
       If not provided to compute a verifier, the --spake2p-verifier-base64 must be provided. 

  --spake2p-verifier-base64 <PASE verifier as base64>
       A raw concatenation of 'W0' and 'L' (67 bytes) as base64 to override the verifier
       auto-computed from the passcode, if provided.

  --spake2p-salt-base64 <PASE salt as base64>
       16-32 bytes of salt to use for the PASE verifier, as base64. If omitted, will be generated
       randomly. If a --spake2p-verifier-base64 is passed, it must match against the salt otherwise
       failure will arise.

  --spake2p-iterations <PASE PBKDF iterations>
       Number of PBKDF iterations to use. If omitted, will be 1000. If a --spake2p-verifier-base64 is
       passed, the iteration counts must match that used to generate the verifier otherwise failure will
       arise.

  --secured-device-port <port>
       A 16-bit unsigned integer specifying the listen port to use for secure device messages (default is 5540).

  --secured-commissioner-port <port>
       A 16-bit unsigned integer specifying the listen port to use for secure commissioner messages (default is 5542). Only valid when app is both device and commissioner

  --unsecured-commissioner-port <port>
       A 16-bit unsigned integer specifying the port to use for unsecured commissioner messages (default is 5550).

  --commissioner-fabric-id <fabricid>
       The fabric ID to be used when this device is a commissioner (default in code is 1).

  --command <command-name>
       A name for a command to execute during startup.

  --PICS <filepath>
       A file containing PICS items.

  --KVS <filepath>
       A file to store Key Value Store items.

  --interface-id <interface>
       A interface id to advertise on.

  --trace_file <file>
       Output trace data to the provided file.
  --trace_log <1/0>
       A value of 1 enables traces to go to the log, 0 disables this (default 0).
  --trace_decode <1/0>
       A value of 1 enables traces decoding, 0 disables this (default 0).
  --cert_error_csr_incorrect_type
       Configure the CSRResponse to be built with an invalid CSR type.
  --cert_error_csr_existing_keypair
       Configure the CSRResponse to be built with a CSR where the keypair already exists.
  --cert_error_csr_nonce_incorrect_type
       Configure the CSRResponse to be built with an invalid CSRNonce type.
  --cert_error_csr_nonce_too_long
       Configure the CSRResponse to be built with a CSRNonce that is longer than expected.
  --cert_error_csr_nonce_invalid
       Configure the CSRResponse to be built with a CSRNonce that does not match the CSRNonce from the CSRRequest.
  --cert_error_nocsrelements_too_long
       Configure the CSRResponse to contains an NOCSRElements larger than the allowed RESP_MAX.
  --cert_error_attestation_signature_incorrect_type
       Configure the CSRResponse to be build with an invalid AttestationSignature type.
  --cert_error_attestation_signature_invalid
       Configure the CSRResponse to be build with an AttestationSignature that does not match what is expected.
  --enable-key <key>
       A 16-byte, hex-encoded key, used to validate TestEventTrigger command of Generial Diagnostics cluster

HELP OPTIONS

  -h, --help
       Print this output and then exit.

  -v, --version
       Print the version and then exit..
```

This PR makes it possible to set the CLI flags for the service.

In addition, it adds a helper app to query the help (CLI usage instructions) by simply running `matter-pi-gpio-commander.help` instead of the long `/snap/matter-pi-gpio-commander/current/bin/lighting-app -h`.