### PR TITLE
Switch from WiringPi pin to BCM GPIO numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,14 @@ Refer to [GPIO.md](GPIO.md) for details.
 
 ### Configure
 #### Set the pin
-> **Warning**  
-> The WiringPi pin numbering assignment differs from the physical pin and Raspberry Pi GPIO (BCM-GPIO).
-> For example, on a Raspberry Pi 4B, the WiringPi pin 8 corresponds to physical pin 3 and GPIO 2.
-> 
-> For reference, visit https://pinout.xyz/pinout/wiringpi
 
 ```bash
-sudo snap set matter-pi-gpio-commander wiringpi-pin=7
+sudo snap set matter-pi-gpio-commander gpio=4
 ```
+
+> **Note**  
+> The GPIO value refers to the Broadcom (BCM) GPIO.
+> For a reference on Raspberry Pi pinout, see https://pinout.xyz
 
 ### Grant access
 The snap uses [interfaces](https://snapcraft.io/docs/interface-management) to allow access to external resources. Depending on the use case, you need to "connect" certain interfaces to grant the necessary access.
@@ -59,7 +58,7 @@ slots:
 > In this case, you may skip the connection or may need to install in development mode.
 > Refer to [GPIO.md](GPIO.md) for details.
 
-The slots are not connected automatically. For example, to connect GPIO-4 (WiringPi pin 7 / physical pin 7):
+The slots are not connected automatically. For example, to grant access to GPIO 4:
 ```bash
 sudo snap connect matter-pi-gpio-commander:gpio pi:bcm-gpio-4
 ```
@@ -139,7 +138,7 @@ Install it as described in the [install](#install) section by replacing `matter-
 This project includes an app to quickly verify the chosen pin and snap GPIO access control without using a Matter Controller.
 The app will toggle the output voltage of the pin to high/low periodically.
 
-To use, install the snap and configure the WiringPi pin as explained above.
+To use, install the snap and configure the GPIO as explained above.
 Then, run it via `sudo snap run matter-pi-gpio-commander.test-blink` snap command or directly:
 ```bash
 sudo matter-pi-gpio-commander.test-blink

--- a/app/src/LightingManager.cpp
+++ b/app/src/LightingManager.cpp
@@ -26,26 +26,26 @@
 
 LightingManager LightingManager::sLight;
 
-#define WiringPiPin "WIRINGPI_PIN"
-static int wiringPiPin;
+#define GPIO "GPIO"
+static int gpio;
 
 CHIP_ERROR LightingManager::Init()
 {
     mState = kState_On;
 
-    char *envWiringPiPin = std::getenv(WiringPiPin);
-    if (envWiringPiPin == NULL)
+    char *envGPIO = std::getenv(GPIO);
+    if (envGPIO == NULL)
     {
-        ChipLogError(AppServer, "Env var %s not set!", WiringPiPin);
+        ChipLogError(AppServer, "Environment variable not set: %s", GPIO);
         exit(-1);
         // TODO: return an appropriate and fatal error
     }
-    ChipLogProgress(AppServer, "WiringPi pin number: %s", envWiringPiPin);
+    ChipLogProgress(AppServer, "Using GPIO %s", envGPIO);
 
-    wiringPiPin = std::stoi(envWiringPiPin);
+    gpio = std::stoi(envGPIO);
 
-    wiringPiSetup();
-    pinMode(wiringPiPin, OUTPUT);
+    wiringPiSetupGpio();
+    pinMode(gpio, OUTPUT);
 
     return CHIP_NO_ERROR;
 }
@@ -115,11 +115,11 @@ void LightingManager::Set(bool aOn)
     if (aOn)
     {
         mState = kState_On;
-        digitalWrite(wiringPiPin, HIGH);
+        digitalWrite(gpio, HIGH);
     }
     else
     {
         mState = kState_Off;
-        digitalWrite(wiringPiPin, LOW);
+        digitalWrite(gpio, LOW);
     }
 }

--- a/app/src/LightingManager.cpp
+++ b/app/src/LightingManager.cpp
@@ -23,6 +23,7 @@
 #include <wiringPi.h>
 #include <cstdlib>
 #include <iostream>
+#include <cstring>
 
 LightingManager LightingManager::sLight;
 
@@ -34,9 +35,9 @@ CHIP_ERROR LightingManager::Init()
     mState = kState_On;
 
     char *envGPIO = std::getenv(GPIO);
-    if (envGPIO == NULL)
+    if (envGPIO == NULL || strlen(envGPIO) == 0)
     {
-        ChipLogError(AppServer, "Environment variable not set: %s", GPIO);
+        ChipLogError(AppServer, "Environment variable not set or empty: %s", GPIO);
         exit(-1);
         // TODO: return an appropriate and fatal error
     }

--- a/snap/local/bin/load-snap-options.sh
+++ b/snap/local/bin/load-snap-options.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
 
-export WIRINGPI_PIN=$(snapctl get wiringpi-pin)
+export GPIO=$(snapctl get gpio)
 
 exec "$@"

--- a/test-blink.cpp
+++ b/test-blink.cpp
@@ -7,12 +7,19 @@
 #include <wiringPi.h>
 #include <cstdlib>
 #include <iostream>
+#include <cstring>
 
 #define GPIO "GPIO"
 
 int main(void)
 {
     char *envGPIO = std::getenv(GPIO);
+    if (envGPIO == NULL || strlen(envGPIO) == 0)
+    {
+        std::cout << "Environment variable not set or empty: " << GPIO << std::endl;
+        return 1;
+    }
+
     int gpio;
     try
     {

--- a/test-blink.cpp
+++ b/test-blink.cpp
@@ -8,33 +8,33 @@
 #include <cstdlib>
 #include <iostream>
 
-#define WiringPiPin "WIRINGPI_PIN"
+#define GPIO "GPIO"
 
 int main(void)
 {
-    char *envWiringPiPin = std::getenv(WiringPiPin);
-    int wiringPiPin;
+    char *envGPIO = std::getenv(GPIO);
+    int gpio;
     try
     {
-        wiringPiPin = std::stoi(envWiringPiPin);
-        std::cout << "WiringPi pin: " << wiringPiPin << std::endl;
+        gpio = std::stoi(envGPIO);
+        std::cout << "GPIO: " << gpio << std::endl;
     }
     catch (std::exception &ex)
     {
-        std::cerr << "Non-integer value for WiringPi pin: " << ex.what() << std::endl;
+        std::cerr << "Non-integer value for GPIO: " << ex.what() << std::endl;
         return 1;
     }
 
-    wiringPiSetup();
-    pinMode(wiringPiPin, OUTPUT);
+    wiringPiSetupGpio();
+    pinMode(gpio, OUTPUT);
 
     for (;;)
     {
-        digitalWrite(wiringPiPin, HIGH);
+        digitalWrite(gpio, HIGH);
         std::cout << "On" << std::endl;
         delay(500);
 
-        digitalWrite(wiringPiPin, LOW);
+        digitalWrite(gpio, LOW);
         std::cout << "Off" << std::endl;
         delay(500);
     }


### PR DESCRIPTION
We switched to Wiring Pi pin numbering for the C++ application (#3). This numbering is made up by the library and unknown to most users. The snap [gpio interface](https://snapcraft.io/docs/gpio-interface) uses the broadcom numbering which adds to the confusion when users need to deal with both in the same application.

The Wiring Pi library provides alternative setup functions to achieve that: http://wiringpi.com/reference/setup/