### PR TITLE
Add CHIP-compliant error handling to the app

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -1,0 +1,111 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "LightingManager.h"
+#include <AppMain.h>
+
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
+#include <app/ConcreteAttributePath.h>
+#include <app/clusters/network-commissioning/network-commissioning.h>
+#include <app/server/Server.h>
+#include <lib/support/logging/CHIPLogging.h>
+#include <platform/Linux/NetworkCommissioningDriver.h>
+
+#if defined(CHIP_IMGUI_ENABLED) && CHIP_IMGUI_ENABLED
+#include <imgui_ui/ui.h>
+#include <imgui_ui/windows/light.h>
+#include <imgui_ui/windows/occupancy_sensing.h>
+#include <imgui_ui/windows/qrcode.h>
+
+#endif
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
+namespace {
+DeviceLayer::NetworkCommissioning::LinuxWiFiDriver sLinuxWiFiDriver;
+Clusters::NetworkCommissioning::Instance sWiFiNetworkCommissioningInstance(0, &sLinuxWiFiDriver);
+} // namespace
+#endif
+
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
+                                       uint8_t * value)
+{
+    if (attributePath.mClusterId == OnOff::Id && attributePath.mAttributeId == OnOff::Attributes::OnOff::Id)
+    {
+        LightingMgr().InitiateAction(*value ? LightingManager::ON_ACTION : LightingManager::OFF_ACTION);
+    }
+}
+
+/** @brief OnOff Cluster Init
+ *
+ * This function is called when a specific cluster is initialized. It gives the
+ * application an opportunity to take care of cluster initialization procedures.
+ * It is called exactly once for each endpoint where cluster is present.
+ *
+ * @param endpoint   Ver.: always
+ *
+ * TODO Issue #3841
+ * emberAfOnOffClusterInitCallback happens before the stack initialize the cluster
+ * attributes to the default value.
+ * The logic here expects something similar to the deprecated Plugins callback
+ * emberAfPluginOnOffClusterServerPostInitCallback.
+ *
+ */
+void emberAfOnOffClusterInitCallback(EndpointId endpoint)
+{
+    // TODO: implement any additional Cluster Server init actions
+}
+
+void ApplicationInit()
+{
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
+    sWiFiNetworkCommissioningInstance.Init();
+#endif
+}
+
+int main(int argc, char * argv[])
+{
+    if (ChipLinuxAppInit(argc, argv) != 0)
+    {
+        return -1;
+    }
+
+    if (LightingMgr().Init() != CHIP_NO_ERROR)
+    {
+        chip::DeviceLayer::PlatformMgr().Shutdown();
+        return -1;
+    }
+
+#if defined(CHIP_IMGUI_ENABLED) && CHIP_IMGUI_ENABLED
+    example::Ui::ImguiUi ui;
+
+    ui.AddWindow(std::make_unique<example::Ui::Windows::QRCode>());
+    ui.AddWindow(std::make_unique<example::Ui::Windows::OccupancySensing>(chip::EndpointId(1), "Occupancy"));
+    ui.AddWindow(std::make_unique<example::Ui::Windows::Light>(chip::EndpointId(1)));
+
+    ChipLinuxAppMainLoop(&ui);
+#else
+    ChipLinuxAppMainLoop();
+#endif
+
+    return 0;
+}

--- a/app/src/LightingManager.cpp
+++ b/app/src/LightingManager.cpp
@@ -40,8 +40,6 @@ CHIP_ERROR LightingManager::Init()
     {
         ChipLogError(AppServer, "Environment variable not set or empty: %s", GPIO);
 
-        chip::DeviceLayer::PlatformMgr().Shutdown();
-        chip::Platform::MemoryShutdown();
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
     ChipLogProgress(AppServer, "Using GPIO %s", envGPIO);

--- a/app/src/LightingManager.cpp
+++ b/app/src/LightingManager.cpp
@@ -20,7 +20,6 @@
 #include "LightingManager.h"
 
 #include <lib/support/logging/CHIPLogging.h>
-#include <platform/CHIPDeviceLayer.h>
 #include <wiringPi.h>
 #include <cstdlib>
 #include <iostream>

--- a/app/src/LightingManager.cpp
+++ b/app/src/LightingManager.cpp
@@ -20,6 +20,7 @@
 #include "LightingManager.h"
 
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/CHIPDeviceLayer.h>
 #include <wiringPi.h>
 #include <cstdlib>
 #include <iostream>
@@ -38,8 +39,10 @@ CHIP_ERROR LightingManager::Init()
     if (envGPIO == NULL || strlen(envGPIO) == 0)
     {
         ChipLogError(AppServer, "Environment variable not set or empty: %s", GPIO);
-        exit(-1);
-        // TODO: return an appropriate and fatal error
+
+        chip::DeviceLayer::PlatformMgr().Shutdown();
+        chip::Platform::MemoryShutdown();
+        return CHIP_ERROR_INVALID_ARGUMENT;
     }
     ChipLogProgress(AppServer, "Using GPIO %s", envGPIO);
 


### PR DESCRIPTION
This PR adds a CHIP-compliant error handling that triggers a fatal error and gracefully shuts down the app when the environment variable `GPIO` is either unset or set to null.

# Test instruction
Build snap from this PR:
```
snapcraft 
```
Validate that the app will raise an error and exit gracefully when the env var `GPIO` is either unset or set to null:
```
sudo snap install ./matter-pi-gpio-commander_0.3.0_amd64.snap --devmode
sudo snap connect matter-pi-gpio-commander:avahi-control
sudo snap set matter-pi-gpio-commander gpio=
sudo snap start matter-pi-gpio-commander
```

```
$ sudo journalctl -f | grep matter-pi-gpio-commander
...
Feb 28 13:55:03 ubuntu matter-pi-gpio-commander.lighting[1899642]: [1677588903.898229][1899642:1899642] CHIP:SVR: Environment variable not set or empty: GPIO
Feb 28 13:55:03 ubuntu matter-pi-gpio-commander.lighting[1899642]: [1677588903.898251][1899642:1899642] CHIP:DL: writing settings to file (/mnt/chip_counters.ini-VW2sPo)
Feb 28 13:55:03 ubuntu matter-pi-gpio-commander.lighting[1899642]: [1677588903.898298][1899642:1899642] CHIP:DL: renamed tmp file to file (/mnt/chip_counters.ini)
Feb 28 13:55:03 ubuntu matter-pi-gpio-commander.lighting[1899642]: [1677588903.898305][1899642:1899642] CHIP:DL: NVS set: chip-counters/total-operational-hours = 0 (0x0)
Feb 28 13:55:03 ubuntu matter-pi-gpio-commander.lighting[1899642]: [1677588903.898306][1899642:1899642] CHIP:DL: Inet Layer shutdown
Feb 28 13:55:03 ubuntu matter-pi-gpio-commander.lighting[1899642]: [1677588903.898308][1899642:1899642] CHIP:DL: BLE shutdown
Feb 28 13:55:03 ubuntu matter-pi-gpio-commander.lighting[1899642]: [1677588903.898309][1899642:1899642] CHIP:DL: System Layer shutdown
Feb 28 13:55:03 ubuntu systemd[1]: snap.matter-pi-gpio-commander.lighting.service: Main process exited, code=exited, status=255/EXCEPTION
Feb 28 13:55:03 ubuntu systemd[1]: snap.matter-pi-gpio-commander.lighting.service: Failed with result 'exit-code'.
```
