### PR TITLE
Add WiringPi's license to snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,6 +30,9 @@ parts:
 
       mkdir -p $CRAFT_PART_INSTALL/lib
       cp -v /usr/local/lib/libwiringPi.so* $CRAFT_PART_INSTALL/lib/
+
+      mkdir -p $CRAFT_PART_INSTALL/usr/share/doc/libwiringPi
+      cp COPYING.LESSER $CRAFT_PART_INSTALL/usr/share/doc/libwiringPi/
     build-packages: [git, gcc, g++]
 
   test-blink:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,6 +3,9 @@ version: "0.3.0"
 summary: Raspberry Pi GPIO as a Matter lighting app
 description: Refer to https://snapcraft.io/matter-pi-gpio-commander
 
+# Apart from WiringPi (LGPL-3.0-only), everything else has Apache-2.0 license
+license: Apache-2.0 OR LGPL-3.0-only
+
 grade: devel
 confinement: strict
 


### PR DESCRIPTION
The CHIP project and the application have Apache-2.0 license. But the [WiringPi library](https://github.com/WiringPi/WiringPi) uses LGPL-3.0. The snap has to:
- [x] set the SPDX expression for both license
- [x] include both license files
```
$ unsquashfs matter-pi-gpio-commander_0.3.0_amd64.snap 
Parallel unsquashfs: Using 16 processors
10 inodes (327 blocks) to write

[===========================================================|] 327/327 100%

created 10 files
created 12 directories
created 0 symlinks
created 0 devices
created 0 fifos
created 0 sockets

$ tree squashfs-root/usr
squashfs-root/usr
└── share
    └── doc
        └── libwiringPi
            └── COPYING.LESSER

3 directories, 1 file

11 directories, 10 files
```
