### PR TITLE
Add gpio config validation

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,3 +1,9 @@
 #!/bin/bash
 
-# This empty script is to allow use of snap options.
+TAG="$SNAP_INSTANCE_NAME.configure"
+
+GPIO=$(snapctl get gpio)
+if [[ -n $GPIO ]] && [[ $GPIO -lt 1 ]]; then
+    logger -t $TAG --stderr "gpio: '$GPIO' is not a positive integer"
+    exit 1
+fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -3,7 +3,7 @@
 TAG="$SNAP_INSTANCE_NAME.configure"
 
 GPIO=$(snapctl get gpio)
-if [[ -n $GPIO ]] && [[ $GPIO -lt 1 ]]; then
+if [[ -n $GPIO ]] && ! [[ $GPIO =~ ^[1-9][0-9]*$ ]]; then
     logger -t $TAG --stderr "gpio: '$GPIO' is not a positive integer"
     exit 1
 fi


### PR DESCRIPTION
This PR adds validation for the `gpio` snap option to reject non-positive integers.

Related to #11 

Example invalid inputs:
```
$ sudo snap set matter-pi-gpio-commander gpio=x
error: cannot perform the following tasks:
- Run configure hook of "matter-pi-gpio-commander" snap (run hook "configure": <13>Mar  1 15:50:40 matter-pi-gpio-commander.configure: gpio: 'x' is not a positive integer)

$ sudo snap set matter-pi-gpio-commander gpio=-1
error: cannot perform the following tasks:
- Run configure hook of "matter-pi-gpio-commander" snap (run hook "configure": <13>Mar  1 15:50:44 matter-pi-gpio-commander.configure: gpio: '-1' is not a positive integer)

$ sudo snap set matter-pi-gpio-commander gpio=0
error: cannot perform the following tasks:
- Run configure hook of "matter-pi-gpio-commander" snap (run hook "configure": <13>Mar  1 15:50:47 matter-pi-gpio-commander.configure: gpio: '0' is not a positive integer)
```
