### PR TITLE
Initialize the actual GPIO state to on/high

### DIFF
--- a/app/src/LightingManager.cpp
+++ b/app/src/LightingManager.cpp
@@ -46,7 +46,7 @@ CHIP_ERROR LightingManager::Init()
     wiringPiSetupGpio();
     pinMode(gpio, OUTPUT);
     
-    // initialize the stored and actual to on
+    // initialize both the stored and actual states to on
     mState = kState_On;
     digitalWrite(gpio, HIGH);
 

--- a/app/src/LightingManager.cpp
+++ b/app/src/LightingManager.cpp
@@ -46,7 +46,7 @@ CHIP_ERROR LightingManager::Init()
     wiringPiSetupGpio();
     pinMode(gpio, OUTPUT);
     
-    // initialize the state to ON
+    // initialize the stored and actual to on
     mState = kState_On;
     digitalWrite(gpio, HIGH);
 

--- a/app/src/LightingManager.cpp
+++ b/app/src/LightingManager.cpp
@@ -32,8 +32,6 @@ static int gpio;
 
 CHIP_ERROR LightingManager::Init()
 {
-    mState = kState_On;
-
     char *envGPIO = std::getenv(GPIO);
     if (envGPIO == NULL || strlen(envGPIO) == 0)
     {
@@ -47,6 +45,10 @@ CHIP_ERROR LightingManager::Init()
 
     wiringPiSetupGpio();
     pinMode(gpio, OUTPUT);
+    
+    // initialize the state to ON
+    mState = kState_On;
+    digitalWrite(gpio, HIGH);
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
Related to #14, this is a quick fix to force a synchronized state. 

Turning on a device upon startup is the state of practice in smart lighting. The negative side effect for this application is that the GPIO will be set HIGH also during app updates.