### PR TITLE
Upgrade to use v1.1.0.1 SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,23 +92,14 @@ For the following examples, we use the [Chip Tool snap](https://snapcraft.io/chi
 ### Commissioning
 
 ```bash
-sudo chip-tool pairing ethernet 110 20202021 3840 192.168.1.111 5540
+sudo snap connect chip-tool:avahi-observe
+sudo chip-tool pairing onnetwork 110 20202021
 ```
 
 where:
 
 -   `110` is the assigned node id
 -   `20202021` is the default passcode (pin code) for the lighting app
--   `3840` is the discriminator id
--   `192.168.1.111` is the IP address of the host for the lighting app
--   `5540` the the port for the lighting app
-
-Alternatively, to commission with discovery which works with DNS-SD:
-
-```bash
-sudo snap connect chip-tool:avahi-observe
-sudo chip-tool pairing onnetwork 110 20202021
-```
 
 ### Command
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,7 +48,7 @@ parts:
     plugin: nil
     source: https://github.com/project-chip/connectedhomeip.git
     source-depth: 1
-    source-tag: v1.0.0.2
+    source-tag: v1.1.0.1
     source-submodules: []
     override-pull: |
       craftctl default
@@ -84,7 +84,20 @@ parts:
       source scripts/activate.sh
       set -u
       
-      cd examples/lighting-app/linux/
+      # Check SNAP_ARCH and install ZAP tool for arm builds
+      if [[ $SNAP_ARCH == "arm64" || $SNAP_ARCH == "armhf" ]]; then
+        ZAP_VERSION=v2023.05.04
+        set -x
+        mkdir -p /opt/zap-${ZAP_VERSION}
+        git clone https://github.com/project-chip/zap.git /opt/zap-${ZAP_VERSION}
+        cd /opt/zap-${ZAP_VERSION}
+        git checkout -b ${ZAP_VERSION}
+        npm ci
+        export ZAP_DEVELOPMENT_PATH=/opt/zap-${ZAP_VERSION}
+      fi
+
+      cd $CRAFT_PART_BUILD
+      cd ../../connectedhomeip/src/examples/lighting-app/linux/
 
       # Copy and replace the application files
       cp -vr $CRAFT_PART_BUILD/* .
@@ -96,6 +109,8 @@ parts:
       
       mkdir -p $CRAFT_PART_INSTALL/bin
       cp out/build/chip-lighting-app $CRAFT_PART_INSTALL/bin/lighting-app        
+    build-snaps:
+      - node/12/stable
     build-packages:
       - git
       - gcc

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -92,6 +92,9 @@ parts:
         git clone https://github.com/project-chip/zap.git /opt/zap-${ZAP_VERSION}
         cd /opt/zap-${ZAP_VERSION}
         git checkout -b ${ZAP_VERSION}
+        npm cache clean --force
+        npm install -g npm@9.7.1
+        npm update --force
         npm ci
         export ZAP_DEVELOPMENT_PATH=/opt/zap-${ZAP_VERSION}
       fi
@@ -110,7 +113,7 @@ parts:
       mkdir -p $CRAFT_PART_INSTALL/bin
       cp out/build/chip-lighting-app $CRAFT_PART_INSTALL/bin/lighting-app        
     build-snaps:
-      - node/12/stable
+      - node/20/stable
     build-packages:
       - git
       - gcc
@@ -129,6 +132,11 @@ parts:
       - libcairo2-dev
       - libreadline-dev
       - generate-ninja
+      - build-essential 
+      - libpango1.0-dev 
+      - libjpeg-dev 
+      - libgif-dev 
+      - librsvg2-dev
 
   local-bin:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,7 +12,7 @@ confinement: strict
 base: core22
 architectures:
   - build-on: arm64
-  - build-on: armhf
+  # - build-on: armhf
   # - build-on: amd64
 
 layout:
@@ -79,28 +79,45 @@ parts:
       # Replace key-value store path:
       sed -i 's/\/tmp/\/mnt/g' src/platform/Linux/CHIPPlatformConfig.h
 
-      # To avoid unrelated activation errors, don't treat unset variables as error
-      set +u
-      source scripts/activate.sh
-      set -u
-      
-      # Check SNAP_ARCH and install ZAP tool for arm builds
-      if [[ $SNAP_ARCH == "arm64" || $SNAP_ARCH == "armhf" ]]; then
-        ZAP_VERSION=v2023.05.04
+      # Install NodeJS and ZAP tool for arm builds
+      if [[ $SNAP_ARCH == "arm64" ]]; then
         set -x
+
+        mkdir node_js
+        cd node_js
+        wget https://nodejs.org/dist/v12.22.12/node-v12.22.12-linux-x64.tar.xz
+        tar xfvJ node-v12.22.12-linux-x64.tar.xz
+        cp -rn node-v12.22.12-linux-x64/. /opt/node-v12.22.12-linux-x64/
+        rm -r node-v12.22.12-linux-x64
+        rm -rf /opt/node
+        rm -rf /usr/bin/node
+        rm -rf /usr/bin/npm
+        rm -rf /usr/bin/npx
+        ln -s /opt/node-v12.22.12-linux-x64 /opt/node
+        ln -s /opt/node/bin/* /usr/bin
+        cd ..
+        rm -rf node_js
+
+        ZAP_VERSION=v2023.05.22-nightly
         mkdir -p /opt/zap-${ZAP_VERSION}
         git clone https://github.com/project-chip/zap.git /opt/zap-${ZAP_VERSION}
         cd /opt/zap-${ZAP_VERSION}
         git checkout -b ${ZAP_VERSION}
         npm cache clean --force
-        npm install -g npm@9.7.1
-        npm update --force
+        npm install -g npm@latest
         npm ci
         export ZAP_DEVELOPMENT_PATH=/opt/zap-${ZAP_VERSION}
       fi
 
       cd $CRAFT_PART_BUILD
-      cd ../../connectedhomeip/src/examples/lighting-app/linux/
+      cd ../../connectedhomeip/src
+
+      # To avoid unrelated activation errors, don't treat unset variables as error
+      set +u
+      source scripts/activate.sh
+      set -u
+
+      cd examples/lighting-app/linux/
 
       # Copy and replace the application files
       cp -vr $CRAFT_PART_BUILD/* .
@@ -112,8 +129,6 @@ parts:
       
       mkdir -p $CRAFT_PART_INSTALL/bin
       cp out/build/chip-lighting-app $CRAFT_PART_INSTALL/bin/lighting-app        
-    build-snaps:
-      - node/20/stable
     build-packages:
       - git
       - gcc
@@ -137,6 +152,7 @@ parts:
       - libjpeg-dev 
       - libgif-dev 
       - librsvg2-dev
+      - wget
 
   local-bin:
     plugin: nil


### PR DESCRIPTION
This PR might resolve #19

### Testing
I have tested the matter-pi-gpio-commander snap built from this PR locally, with the chip-tool snap built from [this PR](https://github.com/canonical/chip-tool-snap/pull/6), and they both work as expected using the same version of Matter SDK v1.1.0.1. The matter-pi-gpio-commander snap could be commissioned and controlled by chip-tool snap.

build:
```
snapcraft -v --debug
```
install and setup matter-pi-gpio-commander:
```
sudo snap install ./matter-pi-gpio-commander_0.3.0_arm64.snap --dangerous
sudo snap set matter-pi-gpio-commander gpio=26

sudo snap connect matter-pi-gpio-commander:avahi-control
sudo snap connect matter-pi-gpio-commander:gpio-memory-control
sudo snap start matter-pi-gpio-commander
```
install and setup chip-tool:
```
sudo snap install ./chip-tool_v1.1.0.1+snap_arm64.snap --dangerous
sudo snap connect chip-tool:avahi-observe
sudo snap connect chip-tool:bluez
```
commison and control:
```
sudo chip-tool pairing onnetwork 110 20202021
sudo chip-tool onoff toggle 110 1
```

Upon successful execution, the LED on the Pi should be controlled by Chip Tool, turning it on or off.


