### PR TITLE
Use Nodejs v18 arm64 and stable ZAP

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -85,7 +85,7 @@ parts:
 
         # Install node and npm
         NODE_VERSION=v18.16.1
-        curl -O https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-arm64.tar.xz
+        wget https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-arm64.tar.xz
         mkdir -p /usr/local/lib/nodejs
         tar -xJf node-$NODE_VERSION-linux-arm64.tar.xz -C /usr/local/lib/nodejs 
         export PATH=/usr/local/lib/nodejs/node-$NODE_VERSION-linux-arm64/bin:$PATH
@@ -144,6 +144,7 @@ parts:
       - libjpeg-dev 
       - libgif-dev 
       - librsvg2-dev
+      - wget
 
   local-bin:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -83,29 +83,21 @@ parts:
       if [[ $SNAP_ARCH == "arm64" ]]; then
         set -x
 
-        mkdir node_js
-        cd node_js
-        wget https://nodejs.org/dist/v12.22.12/node-v12.22.12-linux-x64.tar.xz
-        tar xfvJ node-v12.22.12-linux-x64.tar.xz
-        cp -rn node-v12.22.12-linux-x64/. /opt/node-v12.22.12-linux-x64/
-        rm -r node-v12.22.12-linux-x64
-        rm -rf /opt/node
-        rm -rf /usr/bin/node
-        rm -rf /usr/bin/npm
-        rm -rf /usr/bin/npx
-        ln -s /opt/node-v12.22.12-linux-x64 /opt/node
-        ln -s /opt/node/bin/* /usr/bin
-        cd ..
-        rm -rf node_js
+        # Install node and npm
+        NODE_VERSION=v18.16.1
+        curl -O https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-arm64.tar.xz
+        mkdir -p /usr/local/lib/nodejs
+        tar -xJf node-$NODE_VERSION-linux-arm64.tar.xz -C /usr/local/lib/nodejs 
+        export PATH=/usr/local/lib/nodejs/node-$NODE_VERSION-linux-arm64/bin:$PATH
 
-        ZAP_VERSION=v2023.05.22-nightly
-        mkdir -p /opt/zap-${ZAP_VERSION}
-        git clone https://github.com/project-chip/zap.git /opt/zap-${ZAP_VERSION}
+        # Install ZAP
+        ZAP_VERSION=v2023.05.04
+        rm -fr /opt/zap-${ZAP_VERSION}
+        mkdir /opt/zap-${ZAP_VERSION}
+        git clone --depth=1 --branch=${ZAP_VERSION} https://github.com/project-chip/zap.git /opt/zap-${ZAP_VERSION}
         cd /opt/zap-${ZAP_VERSION}
-        git checkout -b ${ZAP_VERSION}
-        npm cache clean --force
-        npm install -g npm@latest
-        npm ci
+        npm install
+
         export ZAP_DEVELOPMENT_PATH=/opt/zap-${ZAP_VERSION}
       fi
 
@@ -152,7 +144,6 @@ parts:
       - libjpeg-dev 
       - libgif-dev 
       - librsvg2-dev
-      - wget
 
   local-bin:
     plugin: nil


### PR DESCRIPTION
This PR solves several issues, introduced by #20 preventing the build on arm64.

An x64 node distribution was installed on arm64 snap:
```
:: /usr/bin/node: 1: ELF: not found                                                                                  
:: /usr/bin/node: 2: Syntax error: ")" unexpected  
```
The automated build from main branch is failing with the same error: https://snapcraft.io/matter-pi-gpio-commander/builds/2155429

Node and NPM versions were incompatible:
```
+ npm cache clean --force                                                                                 
:: ERROR: npm v9.8.0 is known not to run on Node.js v12.22.12.  This version of npm supports the following node versions: `^14.17.0 || ^16.13.0 || >=18.0.0`.
```

ZAP requires Node v16 or newer for the build. Using v12 failed the build with the following error:
```
npm ERR! Cannot read property '@globalhive/vuejs-tour' of undefined
```

A rebuild failed because the zap repo is cloned on top of existing files:
```
fatal: destination path '/opt/zap-v2023.05.22-nightly' already exists and is not an empty directory.
```