### PR TITLE
Initialize both the stored and actual states to off

### DIFF
--- a/app/src/LightingManager.cpp
+++ b/app/src/LightingManager.cpp
@@ -46,9 +46,9 @@ CHIP_ERROR LightingManager::Init()
     wiringPiSetupGpio();
     pinMode(gpio, OUTPUT);
     
-    // initialize both the stored and actual states to on
-    mState = kState_On;
-    digitalWrite(gpio, HIGH);
+    // initialize both the stored and actual states to off
+    mState = kState_Off;
+    digitalWrite(gpio, LOW);
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
This PR will resolve https://github.com/canonical/matter-pi-gpio-commander/issues/14.

In this matter [file](https://github.com/project-chip/connectedhomeip/blob/master/examples/lighting-app/lighting-common/lighting-app.matter#L2437), a default value of 0 is set for the `onOff` attribute, ensuring that the LED remains off upon initialization. This PR aligns the application's behavior with the default setting. 

## Testing
### Install and setup matter-pigpio-commander:
```
sudo snap install ./matter-pi-gpio-commander_0.3.0+sync-gpio_arm64.snap --dangerous
sudo snap set matter-pi-gpio-commander gpio=26
sudo snap connect matter-pi-gpio-commander:avahi-control
sudo snap connect matter-pi-gpio-commander:gpio-memory-control
sudo snap start matter-pi-gpio-commander
```

### Commission and control via chip-tool:
- toggle
```
sudo snap install chip-tool
sudo snap connect chip-tool:avahi-observe
sudo snap connect chip-tool:bluez
sudo chip-tool pairing onnetwork 110 20202021
sudo chip-tool onoff toggle 110 1
```
The first `chip-tool onoff toggle` [command](https://github.com/canonical/matter-pi-gpio-commander#command) can turn the LED on. Here is the log when the toggle command sent:
```
$ journalctl -f | grep matter-pi-gpio-commander
CHIP:DMG: AccessControl: allowed
CHIP:DMG: Received command for Endpoint=1 Cluster=0x0000_0006 Command=0x0000_0002
CHIP:ZCL: Toggle ep1 on/off from state 0 to 1
```
- on
```
sudo snap install chip-tool
sudo snap connect chip-tool:avahi-observe
sudo snap connect chip-tool:bluez
sudo chip-tool pairing onnetwork 110 20202021
sudo chip-tool onoff on 110 1
```

The first `chip-tool onoff on` command can turn the LED on. Here is the log when the on command sent:
```
$ journalctl -f | grep matter-pi-gpio-commander
CHIP:DMG: AccessControl: allowed
CHIP:DMG: Received command for Endpoint=1 Cluster=0x0000_0006 Command=0x0000_0001
CHIP:ZCL: Toggle ep1 on/off from state 0 to 1
