### PR TITLE
Remove restart delay

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -169,7 +169,6 @@ apps:
       - bin/load-snap-options.sh
     command: bin/run.sh
     install-mode: disable
-    restart-delay: 10s
     plugs:
       - network
       - network-bind


### PR DESCRIPTION
This will make a failing service restart indefinitely at a fixed interval, wasting system resources. The service doesn't depend on any other internal or external component, so a delayed restart is of no use.