### PR TITLE
Upgrade SDK for lighting app Thread fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,17 +57,19 @@ For enabling Thread management:
 sudo snap set matter-pi-gpio-commander args="--thread"
 ```
 
+> **Note**  
+> For Thread management, the application needs to have access to the OpenThread Border Router (OTBR) agent via DBus.
+> When using the [OTBR Snap], this can be achieved by installing the snap and granting the necessary rights; refer to [Thread](#Thread).
+
 For setting multiple flags, concatenate the arguments and set them together:
 ```bash
 sudo snap set matter-pi-gpio-commander args="--thread --ble-device 1"
 ```
 
-> **Note**  
-> For Thread management, the application needs to have access to the OpenThread Border Router (OTBR) agent via DBus.
-> When using the [OTBR Snap], this can be achieved by installing the snap and granting the necessary rights; refer to [Thread](#Thread).
 
 ### Grant access
 The snap uses [interfaces](https://snapcraft.io/docs/interface-management) to allow access to external resources. Depending on the use case, you need to "connect" certain interfaces to grant the necessary access.
+
 #### DNS-SD
 The [avahi-control](https://snapcraft.io/docs/avahi-control-interface) is necessary to allow discovery of the application via DNS-SD:
 
@@ -76,12 +78,12 @@ sudo snap connect matter-pi-gpio-commander:avahi-control
 ```
 
 > **Note**  
-> To make DNS-SD discovery work, the host also needs to have a running avahi-daemon which can be installed with `sudo apt install avahi-daemon` or `sudo snap install avahi`.
+> To make DNS-SD discovery work, the host also needs to have a running avahi-daemon which can be installed with `sudo apt install avahi-daemon`.
 
 
 > **Note**  
-> On **Ubuntu Core**, the `avahi-control` interface is not provided by the system. Instead, it depends on the Avahi snap.
-> To use the `avahi-control` interface from `avahi` snap, run:
+> On **Ubuntu Core**, the `avahi-control` interface is not provided by the system. Instead, it depends on the [Avahi snap](https://snapcraft.io/avahi).
+> To use the interface from that snap, run:
 > ```bash
 > sudo snap connect matter-pi-gpio-commander:avahi-control avahi:avahi-control
 > ```
@@ -92,6 +94,23 @@ The [`gpio-memory-control`](https://snapcraft.io/docs/gpio-memory-control-interf
 ```bash
 sudo snap connect matter-pi-gpio-commander:gpio-memory-control
 ```
+
+#### BLE
+To allow the device to advertise itself over Bluetooth Low Energy:
+```bash
+sudo snap connect matter-pi-gpio-commander:bluez
+```
+
+> **Note**  
+> BLE advertisement depends on BlueZ which can be installed with `sudo apt install bluez`.
+
+> **Note**  
+> On **Ubuntu Core**, the `bluez` interface is not provided by the system. 
+> The interface can instead be consumed from the [BlueZ snap](https://snapcraft.io/bluez):
+> ```bash
+> sudo snap connect matter-pi-gpio-commander:bluez bluez:service
+> ```
+
 
 #### Thread 
 To allow communication with the [OTBR Snap] for Thread management, connect the following interface:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ GENERAL OPTIONS
   ...
 ```
 
+For enabling Thread management, the application needs to have access to the OpenThread Border Router (OTBR) agent via DBus. For using the OTBR snap, refer to [Thread](#Thread).
+
 ### Grant access
 The snap uses [interfaces](https://snapcraft.io/docs/interface-management) to allow access to external resources. Depending on the use case, you need to "connect" certain interfaces to grant the necessary access.
 #### DNS-SD
@@ -76,6 +78,14 @@ The [`gpio-memory-control`](https://snapcraft.io/docs/gpio-memory-control-interf
 
 ```bash
 sudo snap connect matter-pi-gpio-commander:gpio-memory-control
+```
+
+#### Thread 
+The Thread management can be enabled with the help of a running OpenThread Border Router (OTBR) agent reachable via DBus. To do this via the [OTBR snap](https://snapcraft.io/openthread-border-router), install the snap and connect the following interface:
+
+```bash
+sudo snap connect matter-pi-gpio-commander:otbr-dbus-wpan0 \
+                  openthread-border-router:dbus-wpan0
 ```
 
 ### Run

--- a/README.md
+++ b/README.md
@@ -27,11 +27,6 @@ By default, the lighting app runs as a service without any CLI flags.
 The snap allows passing flags to the service via the `args` snap option. 
 This is useful for overriding SDK defaults to customize the application behavior.
 
-For example, to set the `--wifi --passcode 1234` flags:
-```
-snap set matter-pi-gpio-commander args="--wifi --passcode 1234"
-```
-
 To see the list of all flags and SDK default, run the `help` app:
 ```
 $ matter-pi-gpio-commander.help
@@ -49,9 +44,27 @@ GENERAL OPTIONS
        Enable Thread management via ot-agent.
 
   ...
+
 ```
 
-For enabling Thread management, the application needs to have access to the OpenThread Border Router (OTBR) agent via DBus. For using the OTBR snap, refer to [Thread](#Thread).
+For example, to set Passcode for commissioning:
+```bash
+sudo snap set matter-pi-gpio-commander args="--passcode 1234"
+```
+
+For enabling Thread management:
+```bash
+sudo snap set matter-pi-gpio-commander args="--thread"
+```
+
+For setting multiple flags, concatenate the arguments and set them together:
+```bash
+sudo snap set matter-pi-gpio-commander args="--thread --ble-device 1"
+```
+
+> **Note**  
+> For Thread management, the application needs to have access to the OpenThread Border Router (OTBR) agent via DBus.
+> When using the [OTBR Snap], this can be achieved by installing the snap and granting the necessary rights; refer to [Thread](#Thread).
 
 ### Grant access
 The snap uses [interfaces](https://snapcraft.io/docs/interface-management) to allow access to external resources. Depending on the use case, you need to "connect" certain interfaces to grant the necessary access.
@@ -81,7 +94,7 @@ sudo snap connect matter-pi-gpio-commander:gpio-memory-control
 ```
 
 #### Thread 
-The Thread management can be enabled with the help of a running OpenThread Border Router (OTBR) agent reachable via DBus. To do this via the [OTBR snap](https://snapcraft.io/openthread-border-router), install the snap and connect the following interface:
+To allow communication with the [OTBR Snap] for Thread management, connect the following interface:
 
 ```bash
 sudo snap connect matter-pi-gpio-commander:otbr-dbus-wpan0 \
@@ -152,3 +165,6 @@ Then, run it via `sudo snap run matter-pi-gpio-commander.test-blink` snap comman
 ```bash
 sudo matter-pi-gpio-commander.test-blink
 ```
+
+<!-- References -->
+[OTBR Snap]: https://snapcraft.io/openthread-border-router

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,6 +15,14 @@ architectures:
   # - build-on: armhf
   # - build-on: amd64
 
+plugs:
+  # This adds the needed security policy for the communication with 
+  # OpenThread Border Router snap (https://snapcraft.io/openthread-border-router)
+  dbus-otbr-wpan0:
+    interface: dbus
+    bus: system
+    name: io.openthread.BorderRouter.wpan0
+
 layout:
   /mnt:
     bind: $SNAP_COMMON/mnt
@@ -176,6 +184,8 @@ apps:
       - bluez
       - avahi-control
       - gpio-memory-control
+      - dbus-otbr-wpan0
+
   help:
     command: bin/lighting-app -h
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,9 +16,9 @@ architectures:
   # - build-on: amd64
 
 plugs:
-  # This adds the needed security policy for the communication with 
-  # OpenThread Border Router snap (https://snapcraft.io/openthread-border-router)
-  dbus-otbr-wpan0:
+  # This is to communicate with the OpenThread Border Router snap (https://snapcraft.io/openthread-border-router)
+  # when enabling Thread on this application.
+  otbr-dbus-wpan0:
     interface: dbus
     bus: system
     name: io.openthread.BorderRouter.wpan0
@@ -184,7 +184,7 @@ apps:
       - bluez
       - avahi-control
       - gpio-memory-control
-      - dbus-otbr-wpan0
+      - otbr-dbus-wpan0
 
   help:
     command: bin/lighting-app -h

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: matter-pi-gpio-commander
-version: "1.0.0"
+version: "1.0.1"
 summary: Raspberry Pi GPIO as a Matter lighting app
 description: Refer to https://snapcraft.io/matter-pi-gpio-commander
 
@@ -48,7 +48,8 @@ parts:
     plugin: nil
     source: https://github.com/project-chip/connectedhomeip.git
     source-depth: 1
-    source-tag: v1.1.0.1
+    # source-tag: v1.1.0.1
+    source-commit: 6b01cb977127eb8547ce66d5b627061dc2dd6c90
     source-submodules: []
     override-pull: |
       craftctl default
@@ -59,7 +60,7 @@ parts:
     plugin: nil
     source: https://github.com/project-chip/zap.git
     source-depth: 1
-    source-tag: v2023.05.04
+    source-tag: v2023.09.28
     build-environment:
       - NODE_VERSION: v18.16.1
     build-packages:


### PR DESCRIPTION
Upgrade the SDK to hash [6b01cb9](https://github.com/project-chip/connectedhomeip/commit/6b01cb977127eb8547ce66d5b627061dc2dd6c90) to incorporate the following change: https://github.com/project-chip/connectedhomeip/pull/27861

This is to address the bug fix describe at https://github.com/project-chip/connectedhomeip/issues/29738

Install:
```bash
sudo snap install matter-pi-gpio-commander --channel=edge/pr-28
```