### PR TITLE
Use pre built zap binary

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,31 +57,22 @@ parts:
 
   zap:
     plugin: nil
-    source: https://github.com/project-chip/zap.git
-    source-depth: 1
-    source-tag: v2023.05.04
     build-environment:
-      - NODE_VERSION: v18.16.1
+      - ZAP_VERSION: v2023.09.28
     build-packages:
       - build-essential 
-      - libpango1.0-dev 
-      - libjpeg-dev 
-      - libgif-dev 
-      - librsvg2-dev
       - wget
+      - unzip
     override-build: |
       if [[ $SNAP_ARCH == "arm64" ]]; then
-        # Install node+npm
-        NODE=node-$NODE_VERSION-linux-$SNAP_ARCH
-        wget https://nodejs.org/dist/$NODE_VERSION/$NODE.tar.xz
-        tar -xJf $NODE.tar.xz
-        export PATH=$PWD/$NODE/bin:$PATH
+        # Download and unzip the prebuilt ZAP (Zigbee Cluster Library configuration tool and generator) binary for the ARM64 architecture
+        wget https://github.com/project-chip/zap/releases/download/$ZAP_VERSION/zap-linux-$SNAP_ARCH.zip
+        unzip -o zap-linux-$SNAP_ARCH.zip
 
-        # Install zap
-        npm install
+        # Make the binary globally accessible
+        mv zap-cli /usr/local/bin/zap-cli
 
         # Define the environment needed for the app build
-        echo "export PATH=$PWD/$NODE/bin:$PATH" > env
         echo "export ZAP_DEVELOPMENT_PATH=$PWD" >> env
         cat env
       fi
@@ -148,7 +139,6 @@ parts:
       - python3-venv
       - python3-dev
       - python3-pip
-      - unzip
       - libgirepository1.0-dev
       - libcairo2-dev
       - libreadline-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -60,13 +60,12 @@ parts:
     build-environment:
       - ZAP_VERSION: v2023.09.28
     build-packages:
-      - build-essential 
       - wget
       - unzip
     override-build: |
       if [[ $SNAP_ARCH == "arm64" ]]; then
         # Download and unzip the prebuilt ZAP (Zigbee Cluster Library configuration tool and generator) binary for the ARM64 architecture
-        wget https://github.com/project-chip/zap/releases/download/$ZAP_VERSION/zap-linux-$SNAP_ARCH.zip
+        wget --no-verbose https://github.com/project-chip/zap/releases/download/$ZAP_VERSION/zap-linux-$SNAP_ARCH.zip
         unzip -o zap-linux-$SNAP_ARCH.zip
 
         # Define the environment needed for the app build

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,13 +69,8 @@ parts:
         wget https://github.com/project-chip/zap/releases/download/$ZAP_VERSION/zap-linux-$SNAP_ARCH.zip
         unzip -o zap-linux-$SNAP_ARCH.zip
 
-        mkdir -p /bin && mv zap-cli /bin
-
         # Define the environment needed for the app build
-        echo "export ZAP_DEVELOPMENT_PATH=$PWD/bin" >> env
-        echo "export ZAP_INSTALL_PATH=$PWD/bin" >> env
-        echo "export PATH=$PWD/bin:$PATH" > env
-
+        echo "export ZAP_INSTALL_PATH=$PWD" >> env
       fi
 
   lighting:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,12 +69,13 @@ parts:
         wget https://github.com/project-chip/zap/releases/download/$ZAP_VERSION/zap-linux-$SNAP_ARCH.zip
         unzip -o zap-linux-$SNAP_ARCH.zip
 
-        # Make the binary globally accessible
-        mv zap-cli /usr/local/bin/zap-cli
+        mkdir -p /bin && mv zap-cli /bin
 
         # Define the environment needed for the app build
-        echo "export ZAP_DEVELOPMENT_PATH=$PWD" >> env
-        cat env
+        echo "export ZAP_DEVELOPMENT_PATH=$PWD/bin" >> env
+        echo "export ZAP_INSTALL_PATH=$PWD/bin" >> env
+        echo "export PATH=$PWD/bin:$PATH" > env
+
       fi
 
   lighting:


### PR DESCRIPTION
This PR downloads and unzips the prebuilt ZAP (Zigbee Cluster Library configuration tool and generator) binary for the ARM64 architecture, which will make the build more efficient.