### PR TITLE
Use relative path for sourcing env file from zap part

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,7 +77,7 @@ parts:
     plugin: nil
     source: app
     build-environment:
-      - ZAP_ENV: /root/parts/zap/build/env
+      - ZAP_ENV: ../../zap/build/env
     override-build: |
       # Setup ZAP paths; installed in the corresponding part
       test -f $ZAP_ENV && source $ZAP_ENV


### PR DESCRIPTION
This PR will resolve #31 

The build has been tested on the LP remote build and the Pi 4B. 

The application has been tested on the Pi.