### PR TITLE
Update Matter SDK to 1.2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,6 @@ By default, the lighting app runs as a service without any CLI flags.
 The snap allows passing flags to the service via the `args` snap option. 
 This is useful for overriding SDK defaults to customize the application behavior.
 
-For example, to set the `--wifi --passcode 1234` flags:
-```
-snap set matter-pi-gpio-commander args="--wifi --passcode 1234"
-```
-
 To see the list of all flags and SDK default, run the `help` app:
 ```
 $ matter-pi-gpio-commander.help
@@ -49,10 +44,32 @@ GENERAL OPTIONS
        Enable Thread management via ot-agent.
 
   ...
+
 ```
+
+For example, to set Passcode for commissioning:
+```bash
+sudo snap set matter-pi-gpio-commander args="--passcode 1234"
+```
+
+For enabling Thread management:
+```bash
+sudo snap set matter-pi-gpio-commander args="--thread"
+```
+
+> **Note**  
+> For Thread management, the application needs to have access to the OpenThread Border Router (OTBR) agent via DBus.
+> When using the [OTBR Snap], this can be achieved by installing the snap and granting the necessary rights; refer to [Thread](#Thread).
+
+For setting multiple flags, concatenate the arguments and set them together:
+```bash
+sudo snap set matter-pi-gpio-commander args="--thread --ble-device 1"
+```
+
 
 ### Grant access
 The snap uses [interfaces](https://snapcraft.io/docs/interface-management) to allow access to external resources. Depending on the use case, you need to "connect" certain interfaces to grant the necessary access.
+
 #### DNS-SD
 The [avahi-control](https://snapcraft.io/docs/avahi-control-interface) is necessary to allow discovery of the application via DNS-SD:
 
@@ -61,12 +78,12 @@ sudo snap connect matter-pi-gpio-commander:avahi-control
 ```
 
 > **Note**  
-> To make DNS-SD discovery work, the host also needs to have a running avahi-daemon which can be installed with `sudo apt install avahi-daemon` or `sudo snap install avahi`.
+> To make DNS-SD discovery work, the host also needs to have a running avahi-daemon which can be installed with `sudo apt install avahi-daemon`.
 
 
 > **Note**  
-> On **Ubuntu Core**, the `avahi-control` interface is not provided by the system. Instead, it depends on the Avahi snap.
-> To use the `avahi-control` interface from `avahi` snap, run:
+> On **Ubuntu Core**, the `avahi-control` interface is not provided by the system. Instead, it depends on the [Avahi snap](https://snapcraft.io/avahi).
+> To use the interface from that snap, run:
 > ```bash
 > sudo snap connect matter-pi-gpio-commander:avahi-control avahi:avahi-control
 > ```
@@ -76,6 +93,31 @@ The [`gpio-memory-control`](https://snapcraft.io/docs/gpio-memory-control-interf
 
 ```bash
 sudo snap connect matter-pi-gpio-commander:gpio-memory-control
+```
+
+#### BLE
+To allow the device to advertise itself over Bluetooth Low Energy:
+```bash
+sudo snap connect matter-pi-gpio-commander:bluez
+```
+
+> **Note**  
+> BLE advertisement depends on BlueZ which can be installed with `sudo apt install bluez`.
+
+> **Note**  
+> On **Ubuntu Core**, the `bluez` interface is not provided by the system. 
+> The interface can instead be consumed from the [BlueZ snap](https://snapcraft.io/bluez):
+> ```bash
+> sudo snap connect matter-pi-gpio-commander:bluez bluez:service
+> ```
+
+
+#### Thread 
+To allow communication with the [OTBR Snap] for Thread management, connect the following interface:
+
+```bash
+sudo snap connect matter-pi-gpio-commander:otbr-dbus-wpan0 \
+                  openthread-border-router:dbus-wpan0
 ```
 
 ### Run
@@ -142,3 +184,6 @@ Then, run it via `sudo snap run matter-pi-gpio-commander.test-blink` snap comman
 ```bash
 sudo matter-pi-gpio-commander.test-blink
 ```
+
+<!-- References -->
+[OTBR Snap]: https://snapcraft.io/openthread-border-router

--- a/app/BUILD.gn
+++ b/app/BUILD.gn
@@ -41,12 +41,13 @@ executable("chip-lighting-app") {
   sources = [
     "LightingAppCommandDelegate.cpp",
     "include/CHIPProjectAppConfig.h",
+    "include/LightingManager.h",
+    "src/LightingManager.cpp",
     "main.cpp",
   ]
 
   deps = [
     "${chip_root}/examples/lighting-app/lighting-common",
-    "${chip_root}/examples/lighting-app/lighting-common:lighting-manager",
     "${chip_root}/examples/platform/linux:app-main",
     "${chip_root}/src/lib",
     "${chip_root}/third_party/jsoncpp",

--- a/app/BUILD.gn
+++ b/app/BUILD.gn
@@ -1,3 +1,6 @@
+# This file contains partial code copied from:
+# https://github.com/project-chip/connectedhomeip/blob/v1.2.0.1/examples/examples/lighting-app/linux/BUILD.gn
+
 # Copyright (c) 2020 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +19,7 @@ import("//build_overrides/chip.gni")
 
 import("${chip_root}/build/chip/tools.gni")
 import("${chip_root}/src/app/common_flags.gni")
+import("${chip_root}/third_party/imgui/imgui.gni")
 
 assert(chip_build_tools)
 
@@ -35,17 +39,27 @@ config("includes") {
 
 executable("chip-lighting-app") {
   sources = [
+    "LightingAppCommandDelegate.cpp",
     "include/CHIPProjectAppConfig.h",
-    "include/LightingManager.h",
-    "src/LightingManager.cpp",
     "main.cpp",
   ]
 
   deps = [
     "${chip_root}/examples/lighting-app/lighting-common",
+    "${chip_root}/examples/lighting-app/lighting-common:lighting-manager",
     "${chip_root}/examples/platform/linux:app-main",
     "${chip_root}/src/lib",
+    "${chip_root}/third_party/jsoncpp",
   ]
+
+  if (chip_examples_enable_imgui_ui) {
+    deps += [
+      "${chip_root}/examples/common/imgui_ui",
+      "${chip_root}/examples/common/imgui_ui/windows:light",
+      "${chip_root}/examples/common/imgui_ui/windows:occupancy_sensing",
+      "${chip_root}/examples/common/imgui_ui/windows:qrcode",
+    ]
+  }
 
   include_dirs = [ "include" ]
 

--- a/app/include/LightingManager.h
+++ b/app/include/LightingManager.h
@@ -1,4 +1,9 @@
 /*
+ * This file is copied from: 
+ * https://github.com/project-chip/connectedhomeip/blob/v1.2.0.1/examples/lighting-app/lighting-common/include/LightingManager.h
+ */
+
+/*
  *
  *    Copyright (c) 2020 Project CHIP Authors
  *    All rights reserved.

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -1,4 +1,9 @@
 /*
+ * This file is copied from: 
+ * https://github.com/project-chip/connectedhomeip/blob/v1.2.0.1/examples/lighting-app/linux/main.cpp
+ */
+
+/*
  *
  *    Copyright (c) 2020 Project CHIP Authors
  *    All rights reserved.
@@ -16,16 +21,15 @@
  *    limitations under the License.
  */
 
+#include "LightingAppCommandDelegate.h"
 #include "LightingManager.h"
 #include <AppMain.h>
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/ConcreteAttributePath.h>
-#include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/server/Server.h>
 #include <lib/support/logging/CHIPLogging.h>
-#include <platform/Linux/NetworkCommissioningDriver.h>
 
 #if defined(CHIP_IMGUI_ENABLED) && CHIP_IMGUI_ENABLED
 #include <imgui_ui/ui.h>
@@ -39,12 +43,12 @@ using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
 namespace {
-DeviceLayer::NetworkCommissioning::LinuxWiFiDriver sLinuxWiFiDriver;
-Clusters::NetworkCommissioning::Instance sWiFiNetworkCommissioningInstance(0, &sLinuxWiFiDriver);
+
+constexpr const char kChipEventFifoPathPrefix[] = "/tmp/chip_lighting_fifo_";
+NamedPipeCommands sChipNamedPipeCommands;
+LightingAppCommandDelegate sLightingAppCommandDelegate;
 } // namespace
-#endif
 
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
@@ -77,9 +81,21 @@ void emberAfOnOffClusterInitCallback(EndpointId endpoint)
 
 void ApplicationInit()
 {
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-    sWiFiNetworkCommissioningInstance.Init();
-#endif
+    std::string path = kChipEventFifoPathPrefix + std::to_string(getpid());
+
+    if (sChipNamedPipeCommands.Start(path, &sLightingAppCommandDelegate) != CHIP_NO_ERROR)
+    {
+        ChipLogError(NotSpecified, "Failed to start CHIP NamedPipeCommands");
+        sChipNamedPipeCommands.Stop();
+    }
+}
+
+void ApplicationShutdown()
+{
+    if (sChipNamedPipeCommands.Stop() != CHIP_NO_ERROR)
+    {
+        ChipLogError(NotSpecified, "Failed to stop CHIP NamedPipeCommands");
+    }
 }
 
 int main(int argc, char * argv[])
@@ -89,8 +105,10 @@ int main(int argc, char * argv[])
         return -1;
     }
 
-    if (LightingMgr().Init() != CHIP_NO_ERROR)
+    CHIP_ERROR err = LightingMgr().Init();
+    if (err != CHIP_NO_ERROR)
     {
+        ChipLogError(AppServer, "Failed to initialize lighting manager: %" CHIP_ERROR_FORMAT, err.Format());
         chip::DeviceLayer::PlatformMgr().Shutdown();
         return -1;
     }

--- a/app/src/LightingManager.cpp
+++ b/app/src/LightingManager.cpp
@@ -1,4 +1,10 @@
 /*
+ * This file contains partial code copied from:
+ * https://github.com/project-chip/connectedhomeip/blob/v1.2.0.1/examples/lighting-app/lighting-common/src/LightingManager.cpp
+ */
+
+
+/*
  *
  *    Copyright (c) 2020 Project CHIP Authors
  *    Copyright (c) 2019 Google LLC.
@@ -87,12 +93,12 @@ bool LightingManager::InitiateAction(Action_t aAction)
     if (mState == kState_Off && aAction == ON_ACTION)
     {
         action_initiated = true;
-        new_state = kState_On;
+        new_state        = kState_On;
     }
     else if (mState == kState_On && aAction == OFF_ACTION)
     {
         action_initiated = true;
-        new_state = kState_Off;
+        new_state        = kState_Off;
     }
 
     if (action_initiated)

--- a/app/src/LightingManager.cpp
+++ b/app/src/LightingManager.cpp
@@ -93,12 +93,12 @@ bool LightingManager::InitiateAction(Action_t aAction)
     if (mState == kState_Off && aAction == ON_ACTION)
     {
         action_initiated = true;
-        new_state        = kState_On;
+        new_state = kState_On;
     }
     else if (mState == kState_On && aAction == OFF_ACTION)
     {
         action_initiated = true;
-        new_state        = kState_Off;
+        new_state = kState_Off;
     }
 
     if (action_initiated)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: matter-pi-gpio-commander
-version: "1.0.0"
+version: "1.0.1"
 summary: Raspberry Pi GPIO as a Matter lighting app
 description: Refer to https://snapcraft.io/matter-pi-gpio-commander
 
@@ -14,6 +14,14 @@ architectures:
   - build-on: arm64
   # - build-on: armhf
   # - build-on: amd64
+
+plugs:
+  # This is to communicate with the OpenThread Border Router snap (https://snapcraft.io/openthread-border-router)
+  # when enabling Thread on this application.
+  otbr-dbus-wpan0:
+    interface: dbus
+    bus: system
+    name: io.openthread.BorderRouter.wpan0
 
 layout:
   /mnt:
@@ -160,6 +168,8 @@ apps:
       - bluez
       - avahi-control
       - gpio-memory-control
+      - otbr-dbus-wpan0
+
   help:
     command: bin/lighting-app -h
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,7 +48,7 @@ parts:
     plugin: nil
     source: https://github.com/project-chip/connectedhomeip.git
     source-depth: 1
-    source-tag: v1.1.0.1
+    source-tag: v1.2.0.1
     source-submodules: []
     override-pull: |
       craftctl default
@@ -58,7 +58,7 @@ parts:
   zap:
     plugin: nil
     build-environment:
-      - ZAP_VERSION: v2023.09.28
+      - ZAP_VERSION: v2023.10.24-nightly
     build-packages:
       - wget
       - unzip

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -66,7 +66,7 @@ parts:
   zap:
     plugin: nil
     build-environment:
-      - ZAP_VERSION: v2023.10.24-nightly
+      - ZAP_VERSION: v2023.11.13
     build-packages:
       - wget
       - unzip


### PR DESCRIPTION
This PR updates Matter SDK to 1.2.0.1 and rebases local lighting application code to upstream v1.2.0.1.

The minimal requirement for the zap version is v2023.10.24.

The snap could be installed by running:
```
sudo snap install matter-pi-gpio-commander --channel=latest/edge/pr33
```
