### PR TITLE
Add workflow to build for ARM64 arch

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -1,0 +1,27 @@
+name: Snap Builder
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  # Allow manual trigger
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+        
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: build
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.build.outputs.snap }}
+          path: ${{ steps.build.outputs.snap }}

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -11,17 +11,28 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: 
+          - arm64
     steps:
         
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Build snap
-        uses: snapcore/action-build@v1
-        id: build
+      - name: Setub QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: ${{ matrix.platform }}
 
+      - name: Build snap for arm64
+        uses: diddlesnaps/snapcraft-multiarch-action@v1
+        id: build
+        with:
+          architecture: ${{ matrix.platform }}
+      
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ steps.build.outputs.snap }}
+          name: matter-pi-gpio-commander_${{ github.run_number}}_arm64.snap
           path: ${{ steps.build.outputs.snap }}

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setub QEMU
+      - name: Setup QEMU
         uses: docker/setup-qemu-action@v2
         with:
           platforms: ${{ matrix.platform }}

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -34,5 +34,5 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: matter-pi-gpio-commander_${{ github.run_number}}_arm64.snap
+          name: matter-pi-gpio-commander_${{ github.run_number}}_${{ matrix.platform }}.snap
           path: ${{ steps.build.outputs.snap }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,8 +12,6 @@ confinement: strict
 base: core22
 architectures:
   - build-on: arm64
-  # - build-on: armhf
-  # - build-on: amd64
 
 plugs:
   # This is to communicate with the OpenThread Border Router snap (https://snapcraft.io/openthread-border-router)
@@ -56,17 +54,18 @@ parts:
     plugin: nil
     source: https://github.com/project-chip/connectedhomeip.git
     source-depth: 1
-    source-tag: v1.2.0.1
+    source-tag: master
     source-submodules: []
     override-pull: |
       craftctl default
       # shallow clone the submodules
       scripts/checkout_submodules.py --shallow --platform linux
 
+
   zap:
     plugin: nil
     build-environment:
-      - ZAP_VERSION: v2023.11.13
+      - ZAP_VERSION: v2023.12.07
     build-packages:
       - wget
       - unzip


### PR DESCRIPTION
Adding workflow to build for the ARM64 architecture.

The Matter SDK branch is being changed to master to include a fix for the Python environment setup.