### PR TITLE
fix: build problem on arm64 closes #54

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,7 +73,7 @@ parts:
   zap:
     plugin: nil
     build-environment:
-      - ZAP_VERSION: v2024.01.20
+      - ZAP_VERSION: v2024.03.16-nightly
     build-packages:
       - wget
       - unzip


### PR DESCRIPTION
Bump version of ZAP to fix build issue on ARM64.