### PR TITLE
fix: hardcoded path to snap

### DIFF
--- a/tests/snap_test.go
+++ b/tests/snap_test.go
@@ -196,7 +196,7 @@ func TestBlinkOperation(t *testing.T) {
 	// Force kill the process see issue https://github.com/canonical/matter-snap-testing/issues/17
 	go func() {
 		time.Sleep(10 * time.Second)
-		utils.Exec(t, `sudo pkill -f "/snap/matter-pi-gpio-commander/x1/bin/test-blink"`)
+		utils.Exec(t, `sudo pkill -f "test-blink"`)
 	}()
 
 	stdout, _, _ := utils.ExecContextVerbose(t, ctx, "sudo "+snapMatterPiGPIO+".test-blink")


### PR DESCRIPTION
In tests suites, it's needed to kill the processes using pkill, a workaround due to #49.

But the path is hard-coded, like described in #52.

Fixes #52