### PR TITLE
Switch to https protocol for libgpiod git repo

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,7 +49,7 @@ parts:
     # the ARM64 Runner on GH needs the library in it's API v2 form. 
     # Refer to https://github.com/canonical/matter-pi-gpio-commander/issues/53
     plugin: nil
-    source: git://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git
+    source: https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git
     source-branch: v2.1
     override-build: |
 


### PR DESCRIPTION
Introduced by #56
Fixes #62 

Not sure why it fails when cloning with the `git` protocol. Using `https` is a safer option anyway due to the added authentication and encryption.