### PR TITLE
refact: Remove zap part from `snapcraft.yaml`

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -136,12 +136,12 @@ parts:
   lighting:
     after: [libgpiod, test-blink, connectedhomeip, zap]
     plugin: nil
-    source: app
+    source: .
     build-environment:
       - ZAP_ENV: ../../zap/build/env
     override-build: |
 
-      cp $CRAFT_STAGE/gpiod.h linux/include 
+      cp $CRAFT_STAGE/gpiod.h app/linux/include 
 
       # Setup ZAP paths; installed in the corresponding part
       test -f $ZAP_ENV && source $ZAP_ENV

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -115,37 +115,14 @@ parts:
       # shallow clone the submodules
       scripts/checkout_submodules.py --shallow --platform linux
 
-  zap:
-    plugin: nil
-    build-environment:
-      - ZAP_VERSION: v2024.04.16
-    build-packages:
-      - wget
-      - unzip
-    override-build: |
-
-  #     if [[ $SNAP_ARCH == "arm64" ]]; then
-  #       # Download and unzip the prebuilt ZAP (Zigbee Cluster Library configuration tool and generator) binary for the ARM64 architecture
-  #       wget --no-verbose https://github.com/project-chip/zap/releases/download/$ZAP_VERSION/zap-linux-$SNAP_ARCH.zip
-  #       unzip -o zap-linux-$SNAP_ARCH.zip
-
-  #       # Define the environment needed for the app build
-  #       echo "export ZAP_INSTALL_PATH=$PWD" >> env
-  #     fi
-
   lighting:
     after: [libgpiod, test-blink, connectedhomeip]
     plugin: nil
     source: app
-    # build-environment:
-    #   - ZAP_ENV: ../../zap/build/env
     override-build: |
 
       cp $CRAFT_STAGE/gpiod.h linux/include 
 
-      # Setup ZAP paths; installed in the corresponding part
-      #test -f $ZAP_ENV && source $ZAP_ENV
-      
       # Change to SDK's directory to allow caching of the activation
       # regardless of this part's pull and build status.
       cd ../../connectedhomeip/src

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -124,27 +124,27 @@ parts:
       - unzip
     override-build: |
 
-      if [[ $SNAP_ARCH == "arm64" ]]; then
-        # Download and unzip the prebuilt ZAP (Zigbee Cluster Library configuration tool and generator) binary for the ARM64 architecture
-        wget --no-verbose https://github.com/project-chip/zap/releases/download/$ZAP_VERSION/zap-linux-$SNAP_ARCH.zip
-        unzip -o zap-linux-$SNAP_ARCH.zip
+  #     if [[ $SNAP_ARCH == "arm64" ]]; then
+  #       # Download and unzip the prebuilt ZAP (Zigbee Cluster Library configuration tool and generator) binary for the ARM64 architecture
+  #       wget --no-verbose https://github.com/project-chip/zap/releases/download/$ZAP_VERSION/zap-linux-$SNAP_ARCH.zip
+  #       unzip -o zap-linux-$SNAP_ARCH.zip
 
-        # Define the environment needed for the app build
-        echo "export ZAP_INSTALL_PATH=$PWD" >> env
-      fi
+  #       # Define the environment needed for the app build
+  #       echo "export ZAP_INSTALL_PATH=$PWD" >> env
+  #     fi
 
   lighting:
-    after: [libgpiod, test-blink, connectedhomeip, zap]
+    after: [libgpiod, test-blink, connectedhomeip]
     plugin: nil
     source: .
-    build-environment:
-      - ZAP_ENV: ../../zap/build/env
+    # build-environment:
+    #   - ZAP_ENV: ../../zap/build/env
     override-build: |
 
       cp $CRAFT_STAGE/gpiod.h app/linux/include 
 
       # Setup ZAP paths; installed in the corresponding part
-      test -f $ZAP_ENV && source $ZAP_ENV
+      #test -f $ZAP_ENV && source $ZAP_ENV
       
       # Change to SDK's directory to allow caching of the activation
       # regardless of this part's pull and build status.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -136,12 +136,12 @@ parts:
   lighting:
     after: [libgpiod, test-blink, connectedhomeip]
     plugin: nil
-    source: .
+    source: app
     # build-environment:
     #   - ZAP_ENV: ../../zap/build/env
     override-build: |
 
-      cp $CRAFT_STAGE/gpiod.h app/linux/include 
+      cp $CRAFT_STAGE/gpiod.h linux/include 
 
       # Setup ZAP paths; installed in the corresponding part
       #test -f $ZAP_ENV && source $ZAP_ENV


### PR DESCRIPTION
* Remove non-necessary anymore ZAP part from `snapcraft.yaml`
* Fixes #61 