### PR TITLE
refact: Only use the arm64 runner to run the tests.

### DIFF
--- a/.github/workflows/build-and-test-snap.yml
+++ b/.github/workflows/build-and-test-snap.yml
@@ -34,6 +34,7 @@ jobs:
           path: ${{ steps.build.outputs.snap }}
 
   test-arm64:
+    needs: build-arm64
     runs-on: Ubuntu_ARM64_4C_16G_01
     steps:
       - name: Checkout code
@@ -56,8 +57,8 @@ jobs:
         env:
           MOCK_GPIO: true
           SKIP_TEARDOWN_REMOVAL: true
-          LOCAL_SERVICE_SNAP: ../matter-pi-gpio-commander_${{ github.run_number}}_arm64.snap
-        run: go test -failfast -p 1 -timeout 20m -v
+          LOCAL_SERVICE_SNAP: ../matter-pi-gpio-commander_2.0.0_arm64.snap
+        run: ls -la && go test -failfast -p 1 -timeout 20m -v
 
       - name: Upload snap logs
         if: always()
@@ -65,10 +66,3 @@ jobs:
         with:
           name: snap-logs
           path: tests/*.log
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: matter-pi-gpio-commander_${{ github.run_number}}_arm64.snap
-          path: ${{ steps.snapcraft.outputs.snap }}
-  

--- a/.github/workflows/build-and-test-snap.yml
+++ b/.github/workflows/build-and-test-snap.yml
@@ -9,16 +9,41 @@ on:
   workflow_dispatch:
 
 jobs:
+  build-arm64:
+    runs-on: ubuntu-latest
+    steps:
 
-  build-and-test-arm64:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Build snap for arm64
+        uses: diddlesnaps/snapcraft-multiarch-action@v1
+        id: build
+        with:
+          architecture: arm64
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: matter-pi-gpio-commander_${{ github.run_number}}_arm64.snap
+          path: ${{ steps.build.outputs.snap }}
+
+  test-arm64:
     runs-on: Ubuntu_ARM64_4C_16G_01
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-   
-      - name: Build Snap
-        uses: snapcore/action-build@v1
-        id: snapcraft
+
+      - name: Download snap artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: matter-pi-gpio-commander_${{ github.run_number}}_arm64.snap
+          path: .
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -31,7 +56,7 @@ jobs:
         env:
           MOCK_GPIO: true
           SKIP_TEARDOWN_REMOVAL: true
-          LOCAL_SERVICE_SNAP: ../${{ steps.snapcraft.outputs.snap }}
+          LOCAL_SERVICE_SNAP: ../matter-pi-gpio-commander_${{ github.run_number}}_arm64.snap
         run: go test -failfast -p 1 -timeout 20m -v
 
       - name: Upload snap logs

--- a/.github/workflows/build-and-test-snap.yml
+++ b/.github/workflows/build-and-test-snap.yml
@@ -57,8 +57,8 @@ jobs:
         env:
           MOCK_GPIO: true
           SKIP_TEARDOWN_REMOVAL: true
-          LOCAL_SERVICE_SNAP: ../matter-pi-gpio-commander_2.0.0_arm64.snap
-        run: ls -la && go test -failfast -p 1 -timeout 20m -v
+          LOCAL_SERVICE_SNAP: ../matter-pi-gpio-commander_*_arm64.snap
+        run: go test -failfast -p 1 -timeout 20m -v
 
       - name: Upload snap logs
         if: always()

--- a/.github/workflows/build-and-test-snap.yml
+++ b/.github/workflows/build-and-test-snap.yml
@@ -10,22 +10,31 @@ on:
 
 jobs:
   build-arm64:
-    runs-on: ubuntu-latest
+    # ARM64 runner
+    runs-on: Ubuntu_ARM64_4C_16G_01
+
+    # runs-on: ubuntu-latest
     steps:
 
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
-      - name: Build snap for arm64
-        uses: diddlesnaps/snapcraft-multiarch-action@v1
+      # Native Build on ARM64
+      - name: Build Snap
+        uses: snapcore/action-build@v1
         id: build
-        with:
-          architecture: arm64
+
+      # QEMU Build on ARM64
+      # - name: Setup QEMU
+      #   uses: docker/setup-qemu-action@v3
+      #   with:
+      #     platforms: arm64
+
+      # - name: Build snap for arm64
+      #   uses: diddlesnaps/snapcraft-multiarch-action@v1
+      #   id: build
+      #   with:
+      #     architecture: arm64
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
* Justification on [this conversation](https://github.com/canonical/matter-pi-gpio-commander/pull/57#issuecomment-2072247372).

Related to #53