### PR TITLE
Set SDK to v1.3.0.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: matter-pi-gpio-commander
-version: "2.0.0"
+version: "2.1.0"
 summary: Raspberry Pi GPIO as a Matter lighting app
 description: Refer to https://snapcraft.io/matter-pi-gpio-commander
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: matter-pi-gpio-commander
-version: "2.1.0"
+version: "2.0.0+matter1.3.0.0"
 summary: Raspberry Pi GPIO as a Matter lighting app
 description: Refer to https://snapcraft.io/matter-pi-gpio-commander
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,8 @@
 name: matter-pi-gpio-commander
-version: "2.0.0+matter1.3.0.0"
+version: "2.0"
 summary: Raspberry Pi GPIO as a Matter lighting app
 description: Refer to https://snapcraft.io/matter-pi-gpio-commander
+adopt-info: connectedhomeip
 
 # Apart from libgpiod (LGPL-2.1-or-later), everything else has Apache-2.0 license
 license: Apache-2.0 AND LGPL-2.1-or-later
@@ -114,6 +115,11 @@ parts:
       craftctl default
       # shallow clone the submodules
       scripts/checkout_submodules.py --shallow --platform linux
+
+    override-build: |
+      # add SDK's tag, fall back to the commit hash
+      CHIP_REF=$(git describe --exact-match --tags 2> /dev/null || git rev-parse --short HEAD)
+      craftctl set version=$(craftctl get version)+chip-$CHIP_REF
 
   lighting:
     after: [libgpiod, test-blink, connectedhomeip]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -107,7 +107,7 @@ parts:
     plugin: nil
     source: https://github.com/project-chip/connectedhomeip.git
     source-depth: 1
-    source-tag: master
+    source-tag: v1.3.0.0
     source-submodules: []
     override-pull: |
 


### PR DESCRIPTION
## Summary
[Matter v1.3](https://csa-iot.org/newsroom/matter-1-3-specification-released/) was released in May 2024. 
This PR switches the connectedhomeip tag to [v1.3.0.0](https://github.com/project-chip/connectedhomeip/tree/v1.3.0.0) on the matter-v1.3 release branch.

## Testing Steps

Generic tests, ran on Pi5 with Ubuntu 24.04:
```
$ LOCAL_SERVICE_SNAP=../matter-pi-gpio-commander_2.0.0_arm64.snap GPIO_CHIP=4 GPIO_LINE=4 go test -v -failfast -count 1
2024/06/18 11:15:25 [CLEAN]
2024/06/18 11:15:25 [exec] sudo snap remove --purge matter-pi-gpio-commander
2024/06/18 11:15:25 [stderr] snap "matter-pi-gpio-commander" is not installed
2024/06/18 11:15:25 [exec] sudo snap remove --purge chip-tool
2024/06/18 11:15:25 [stderr] snap "chip-tool" is not installed
2024/06/18 11:15:25 [SETUP]
2024/06/18 11:15:25 [exec] sudo snap install --dangerous ../matter-pi-gpio-commander_2.0.0_arm64.snap
2024/06/18 11:15:30 [stdout] matter-pi-gpio-commander 2.0.0 installed
2024/06/18 11:15:30 [exec] sudo snap connect matter-pi-gpio-commander:custom-gpio matter-pi-gpio-commander:custom-gpio-dev
2024/06/18 11:15:32 [exec] sudo snap connect matter-pi-gpio-commander:avahi-control 
2024/06/18 11:15:33 [exec] sudo snap connect matter-pi-gpio-commander:bluez 
2024/06/18 11:15:34 [exec] sudo snap set matter-pi-gpio-commander gpiochip='4'
2024/06/18 11:15:35 [exec] sudo snap set matter-pi-gpio-commander gpio='4'
=== RUN   TestBlinkOperation
    snap_test.go:202: [exec] sudo matter-pi-gpio-commander.test-blink
    exec.go:140: [stdout] GPIO: 4
    exec.go:140: [stdout] GPIOCHIP: 4
    exec.go:140: [stdout] Setting GPIO 4 to Off
    exec.go:140: [stdout] Setting GPIO 4 to On
    exec.go:140: [stdout] Setting GPIO 4 to Off
    exec.go:140: [stdout] Setting GPIO 4 to On
    exec.go:140: [stdout] Setting GPIO 4 to Off
    exec.go:140: [stdout] Setting GPIO 4 to On
    exec.go:140: [stdout] Setting GPIO 4 to Off
    exec.go:140: [stdout] Setting GPIO 4 to On
    exec.go:140: [stdout] Setting GPIO 4 to Off
    exec.go:140: [stdout] Setting GPIO 4 to On
--- PASS: TestBlinkOperation (5.00s)
=== RUN   TestWifiMatterCommander
    snap.go:28: [exec] sudo snap install chip-tool --channel=latest/edge
    exec.go:140: [stdout] chip-tool (edge) 4cdce52a+snap from Canonical IoT Labs installed
2024/06/18 11:15:47 [exec] sudo snap connect chip-tool:avahi-observe 
    snap.go:161: [exec] sudo snap start --enable matter-pi-gpio-commander
    exec.go:140: [stdout] Started.
=== RUN   TestWifiMatterCommander/Commission
    snap_test.go:233: [exec] sudo chip-tool pairing onnetwork 110 20202021
    snap_test.go:235: stderr: 
=== RUN   TestWifiMatterCommander/Control
    snap_test.go:240: [exec] sudo chip-tool onoff toggle 110 1
    snap_test.go:240: [exec] sudo chip-tool onoff toggle 110 1
    snap_test.go:240: [exec] sudo chip-tool onoff toggle 110 1
    snap_test.go:240: [exec] sudo chip-tool onoff toggle 110 1
=== NAME  TestWifiMatterCommander
    snap.go:170: [exec] sudo snap stop --disable matter-pi-gpio-commander
    exec.go:140: [stdout] Stopped.
    snap.go:62: [exec] sudo snap remove --purge chip-tool
    exec.go:140: [stdout] chip-tool removed
--- PASS: TestWifiMatterCommander (15.04s)
    --- PASS: TestWifiMatterCommander/Commission (0.84s)
    --- PASS: TestWifiMatterCommander/Control (1.79s)
PASS
2024/06/18 11:15:55 [TEARDOWN]
2024/06/18 11:15:55 [exec] (sudo journalctl --since "2024-06-18 11:15:25" --no-pager | grep "matter-pi-gpio-commander"|| true) > matter-pi-gpio-commander.log
Wrote snap logs to /home/ubuntu/matter-pi-gpio-commander/tests/matter-pi-gpio-commander.log
2024/06/18 11:15:55 [exec] rm ../matter-pi-gpio-commander_2.0.0_arm64.snap
2024/06/18 11:15:55 Removing installed snap: true
2024/06/18 11:15:55 [exec] sudo snap remove --purge matter-pi-gpio-commander
2024/06/18 11:16:01 [stdout] matter-pi-gpio-commander removed
2024/06/18 11:16:01 [exec] ./gpio-mock.sh teardown
ok  	matter-pi-gpio-commander-tests	35.555s
```

Thread tests, using Ubuntu 23.10 (amd64) as the local machine and Ubuntu 24.04 on Pi5 as the remote:
```
$ REMOTE_SNAP_PATH="~/matter-pi-gpio-commander/matter-pi-gpio-commander_2.0.0_arm64.snap" REMOTE_GPIO_CHIP="4" REMOTE_GPIO_LINE="4" LOCAL_INFRA_IF="enp2s0" REMOTE_INFRA_IF="eth0" REMOTE_USER="ubuntu" REMOTE_PASSWORD="raspberry" REMOTE_HOST="192.168.1.24" go test -v -failfast -count 1 ./thread_tests
=== RUN   TestThread
    snap.go:62: [exec] sudo snap remove --purge chip-tool
[sudo] password for farshid: 
    exec.go:140: [stderr] snap "chip-tool" is not installed
2024/06/18 16:03:12 [exec] sudo snap install chip-tool --channel=latest/edge
2024/06/18 16:03:16 [stdout] chip-tool (edge) 4cdce52a+snap from Canonical IoT Labs installed
    snap.go:81: [exec] sudo snap connect chip-tool:avahi-observe 
    snap.go:81: [exec] sudo snap connect chip-tool:bluez 
    snap.go:81: [exec] sudo snap connect chip-tool:process-control 
    snap.go:62: [exec] sudo snap remove --purge openthread-border-router
    exec.go:140: [stderr] snap "openthread-border-router" is not installed
    snap.go:28: [exec] sudo snap install openthread-border-router --channel=latest/edge
    exec.go:140: [stdout] openthread-border-router (edge) thread-reference-20230710+snap from Canonical IoT Labs installed
2024/06/18 16:03:22 [exec] sudo snap connect openthread-border-router:avahi-control 
2024/06/18 16:03:22 [exec] sudo snap connect openthread-border-router:firewall-control 
2024/06/18 16:03:23 [exec] sudo snap connect openthread-border-router:raw-usb 
2024/06/18 16:03:24 [exec] sudo snap connect openthread-border-router:network-control 
2024/06/18 16:03:25 [exec] sudo snap connect openthread-border-router:bluetooth-control 
2024/06/18 16:03:26 [exec] sudo snap connect openthread-border-router:bluez 
2024/06/18 16:03:27 [exec] sudo snap set openthread-border-router infra-if='enp2s0'
    snap.go:161: [exec] sudo snap start --enable openthread-border-router
    exec.go:140: [stdout] Started.
    local.go:105: Retry 1/10: Waiting for expected content in logs: Start Thread Border Agent: OK
    snap.go:138: [exec] sudo journalctl --since "2024-06-18 16:03:27" --no-pager | grep "openthread-border-router"|| true
    local.go:109: Found expected content in logs: Start Thread Border Agent: OK
    local.go:57: [exec] sudo openthread-border-router.ot-ctl dataset init new
    local.go:58: [exec] sudo openthread-border-router.ot-ctl dataset commit active
    local.go:59: [exec] sudo openthread-border-router.ot-ctl ifconfig up
    local.go:60: [exec] sudo openthread-border-router.ot-ctl thread start
    config.go:59: Retry 1/10: Waiting for expected content in logs: Thread Network
    snap.go:138: [exec] sudo journalctl --since "2024-06-18 16:03:27" --no-pager | grep "openthread-border-router"|| true
    config.go:59: Retry 2/10: Waiting for expected content in logs: Thread Network
    snap.go:138: [exec] sudo journalctl --since "2024-06-18 16:03:27" --no-pager | grep "openthread-border-router"|| true
    config.go:59: Retry 3/10: Waiting for expected content in logs: Thread Network
    snap.go:138: [exec] sudo journalctl --since "2024-06-18 16:03:27" --no-pager | grep "openthread-border-router"|| true
    config.go:59: Retry 4/10: Waiting for expected content in logs: Thread Network
    snap.go:138: [exec] sudo journalctl --since "2024-06-18 16:03:27" --no-pager | grep "openthread-border-router"|| true
    config.go:59: Retry 5/10: Waiting for expected content in logs: Thread Network
    snap.go:138: [exec] sudo journalctl --since "2024-06-18 16:03:27" --no-pager | grep "openthread-border-router"|| true
    config.go:59: Retry 6/10: Waiting for expected content in logs: Thread Network
    snap.go:138: [exec] sudo journalctl --since "2024-06-18 16:03:27" --no-pager | grep "openthread-border-router"|| true
    config.go:59: Retry 7/10: Waiting for expected content in logs: Thread Network
    snap.go:138: [exec] sudo journalctl --since "2024-06-18 16:03:27" --no-pager | grep "openthread-border-router"|| true
    config.go:59: Retry 8/10: Waiting for expected content in logs: Thread Network
    snap.go:138: [exec] sudo journalctl --since "2024-06-18 16:03:27" --no-pager | grep "openthread-border-router"|| true
    config.go:63: Found expected content in logs: Thread Network
    local.go:65: [exec] sudo openthread-border-router.ot-ctl dataset active -x | awk '{print $NF}' | grep --invert-match "Done"
    remote.go:100: SSH: connected to 192.168.1.24
    remote.go:125: [exec-ssh] sudo snap remove --purge openthread-border-router
    remote.go:125: [exec-ssh] sudo snap install openthread-border-router --edge
    remote.go:125: [exec-ssh] sudo snap set openthread-border-router infra-if='eth0'
    remote.go:125: [exec-ssh] sudo snap set openthread-border-router webgui-port=31190
    remote.go:125: [exec-ssh] sudo snap connect openthread-border-router:firewall-control
    remote.go:125: [exec-ssh] sudo snap connect openthread-border-router:raw-usb
    remote.go:125: [exec-ssh] sudo snap connect openthread-border-router:network-control
    remote.go:125: [exec-ssh] sudo snap start openthread-border-router
    remote.go:128: Retry 1/10: Waiting for expected content in logs: 'Start Thread Border Agent: OK'
    remote.go:128: [exec-ssh] sudo journalctl --utc --since "2024-06-18 14:03:39" --no-pager | grep "openthread-border-router"|| true
    remote.go:128: Found expected content in logs: 'Start Thread Border Agent: OK'
    remote.go:129: OTBR on remote device is ready
    remote.go:159: [exec-ssh] sudo snap remove --purge matter-pi-gpio-commander
    remote.go:160: 
    remote.go:159: [exec-ssh] sudo snap install --dangerous ~/matter-pi-gpio-commander/matter-pi-gpio-commander_2.0.0_arm64.snap
    remote.go:160: matter-pi-gpio-commander 2.0.0 installed
        
    remote.go:159: [exec-ssh] sudo snap connect matter-pi-gpio-commander:custom-gpio matter-pi-gpio-commander:custom-gpio-dev
    remote.go:160: 
    remote.go:159: [exec-ssh] sudo snap set matter-pi-gpio-commander args="--thread"
    remote.go:160: 
    remote.go:159: [exec-ssh] sudo snap set matter-pi-gpio-commander gpiochip="4"
    remote.go:160: 
    remote.go:159: [exec-ssh] sudo snap set matter-pi-gpio-commander gpio="4"
    remote.go:160: 
    remote.go:159: [exec-ssh] sudo snap connect matter-pi-gpio-commander:avahi-control
    remote.go:160: 
    remote.go:159: [exec-ssh] sudo snap connect matter-pi-gpio-commander:otbr-dbus-wpan0 openthread-border-router:dbus-wpan0
    remote.go:160: 
    remote.go:159: [exec-ssh] sudo snap start matter-pi-gpio-commander
    remote.go:160: Started.
        
    remote.go:163: Retry 1/10: Waiting for expected content in logs: 'CHIP:IN: TransportMgr initialized'
    remote.go:163: [exec-ssh] sudo journalctl --utc --since "2024-06-18 14:03:52" --no-pager | grep "matter-pi-gpio-commander"|| true
    remote.go:163: Found expected content in logs: 'CHIP:IN: TransportMgr initialized'
    remote.go:164: Matter PI GPIO Commander on remote device is ready
=== RUN   TestThread/Commission
    thread_test.go:20: [exec] sudo chip-tool pairing code-thread 110 hex:0e080000000000010000000300000e35060004001fffe00208342457b68897cfc70708fd53e2b44dc0120105101d04cc7e12850b5f3797ebd9fb44d928030f4f70656e5468726561642d643932390102d9290410756386f9f871b1440a37a3e8075421810c0402a0f7f8 34970112332 2>&1
=== RUN   TestThread/Control
    thread_test.go:28: [exec] sudo chip-tool onoff toggle 110 1 2>&1
    thread_test.go:33: Retry 1/10: Waiting for expected content in logs: 'CHIP:ZCL: Toggle ep1 on/off'
    thread_test.go:33: [exec-ssh] sudo journalctl --utc --since "2024-06-18 14:04:05" --no-pager | grep "matter-pi-gpio-commander"|| true
    thread_test.go:33: Found expected content in logs: 'CHIP:ZCL: Toggle ep1 on/off'
=== NAME  TestThread
    thread_test.go:37: [exec] sudo chip-tool onoff off 110 1 2>&1
    remote.go:135: [exec-ssh] sudo snap remove --purge matter-pi-gpio-commander
    remote.go:106: [exec-ssh] sudo snap remove --purge openthread-border-router
    snap.go:62: [exec] sudo snap remove --purge openthread-border-router
    exec.go:140: [stdout] openthread-border-router removed
    snap.go:62: [exec] sudo snap remove --purge chip-tool
    exec.go:140: [stdout] chip-tool removed
--- PASS: TestThread (86.10s)
    --- PASS: TestThread/Commission (0.97s)
    --- PASS: TestThread/Control (1.44s)
PASS
ok  	matter-pi-gpio-commander-tests/thread_tests	86.106s
```

The snap has been released to `latest/candidate/v1.3.0`, so the testing should be possible via that channel too.

<!-- Reminders:
 - Incremented the snap version
 - Added or updated tests
 - Updated the CI/CD pipelines
 - Updated the README(s)
 - Updated external documentation
-->
