### PR TITLE
Add SDK reference to snap version, drop version's patch

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,8 @@
 name: matter-pi-gpio-commander
-version: "2.0.0"
+version: "2.0"
 summary: Raspberry Pi GPIO as a Matter lighting app
 description: Refer to https://snapcraft.io/matter-pi-gpio-commander
+adopt-info: connectedhomeip
 
 # Apart from libgpiod (LGPL-2.1-or-later), everything else has Apache-2.0 license
 license: Apache-2.0 AND LGPL-2.1-or-later
@@ -114,6 +115,11 @@ parts:
       craftctl default
       # shallow clone the submodules
       scripts/checkout_submodules.py --shallow --platform linux
+
+    override-build: |
+      # add SDK's tag, fall back to the commit hash
+      CHIP_REF=$(git describe --exact-match --tags 2> /dev/null || git rev-parse --short HEAD)
+      craftctl set version=$(craftctl get version)+chip-$CHIP_REF
 
   lighting:
     after: [libgpiod, test-blink, connectedhomeip]


### PR DESCRIPTION
## Summary
- Add SDK reference to snap version; closes #72 
- Drop version's patch. See below.

The following options have been considered:
### Option 1
Don't use semver. In semver, the MINOR should change when the SDK changes. We can't easily automate that.

That gives us: 
- latest/stable: `2.0+chip-v1.3.0.0`
- latest/edge: `2.0+chip-hash`
### Option 2
Use semver's pre-release versioning on edge, and stable on releases.

That gives us:
- latest/stable: `2.0.0+chip-1.3.0.0`
- latest/edge: `2.1.0-chip-hash` (note the bumped MINOR and use of hyphen to indicate pre-release).

Option 2 was discarded as the manual versioning efforts are high and prone to human errors. Moreover, the snap doesn't require that level of details in the versioning.

Related to #74 

## Testing Steps
<!-- Steps to test the changes. Remove if not relevant -->

```console
$ snapcraft -v
...
Creating snap package...                                                                                                                                 
Created snap package matter-pi-gpio-commander_2.0+chip-f6ac9266_arm64.snap 
```

<!-- Reminders:
 - Incremented the snap version
 - Added or updated tests
 - Updated the CI/CD pipelines
 - Updated the README(s)
 - Updated external documentation
-->
