### PR TITLE
ci: Fix GPIO simulation issue by using linux-azure drivers

### DIFF
--- a/tests/gpio-mock.sh
+++ b/tests/gpio-mock.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 if [ "$1" = "teardown" ]; then
-	sudo rmmod gpio_mockup
-	rm -rf gpio-mockup
-	exit 0
+  sudo rmmod gpio_mockup
+  rm -rf gpio-mockup
+  exit 0
 fi
 
 mkdir gpio-mockup
@@ -16,11 +16,15 @@ sudo apt-get install -y build-essential flex bison make
 
 kernel_major_minor=$(uname -r | cut -d'.' -f1-2)
 
-echo "Kernel major minor version: $kernel_major_minor"
+echo "Kernel version: $(uname -r)"
+
+# From investigations that's what is missing between the linux headers and
+# the driver
+commit=36aa129f22
 
 # Get GPIO Mockup driver
-wget https://raw.githubusercontent.com/torvalds/linux/v$kernel_major_minor/drivers/gpio/gpio-mockup.c
-wget https://raw.githubusercontent.com/torvalds/linux/v$kernel_major_minor/drivers/gpio/gpiolib.h
+wget https://raw.githubusercontent.com/torvalds/linux/$commit/drivers/gpio/gpio-mockup.c
+wget https://raw.githubusercontent.com/torvalds/linux/$commit/drivers/gpio/gpiolib.h
 
 # Create Makefile
 echo "
@@ -30,8 +34,7 @@ all:
 	make -C /lib/modules/\$(KVERSION)/build M=\$(PWD) modules
 clean:
 	make -C /lib/modules/\$(KVERSION)/build M=\$(PWD) clean
-" > Makefile
-
+" >Makefile
 
 make -j$(nproc)
 
@@ -42,3 +45,4 @@ gpio_mock_chip=$(ls /dev/gpiochip* | sort -n | head -n 1)
 echo "GPIO Mockup chip: $gpio_mock_chip"
 
 cd ..
+

--- a/tests/gpio-mock.sh
+++ b/tests/gpio-mock.sh
@@ -16,9 +16,11 @@ sudo apt-get install -y build-essential flex bison make
 
 echo "Kernel version: $(uname -r)"
 
+. /etc/os-release
+
 # Get GPIO Mockup driver
-wget https://git.launchpad.net/~canonical-kernel/ubuntu/+source/linux-azure/+git/jammy/plain/drivers/gpio/gpio-mockup.c
-wget https://git.launchpad.net/~canonical-kernel/ubuntu/+source/linux-azure/+git/jammy/plain/drivers/gpio/gpiolib.h
+wget https://git.launchpad.net/~canonical-kernel/ubuntu/+source/linux-azure/+git/$UBUNTU_CODENAME/plain/drivers/gpio/gpio-mockup.c
+wget https://git.launchpad.net/~canonical-kernel/ubuntu/+source/linux-azure/+git/$UBUNTU_CODENAME/plain/drivers/gpio/gpiolib.h
 
 # Create Makefile
 echo "

--- a/tests/gpio-mock.sh
+++ b/tests/gpio-mock.sh
@@ -14,17 +14,11 @@ sudo apt-get update
 sudo apt-get install -y linux-headers-$(uname -r)
 sudo apt-get install -y build-essential flex bison make
 
-kernel_major_minor=$(uname -r | cut -d'.' -f1-2)
-
 echo "Kernel version: $(uname -r)"
 
-# From investigations that's what is missing between the linux headers and
-# the driver
-commit=36aa129f22
-
 # Get GPIO Mockup driver
-wget https://raw.githubusercontent.com/torvalds/linux/$commit/drivers/gpio/gpio-mockup.c
-wget https://raw.githubusercontent.com/torvalds/linux/$commit/drivers/gpio/gpiolib.h
+wget https://git.launchpad.net/~canonical-kernel/ubuntu/+source/linux-azure/+git/jammy/plain/drivers/gpio/gpio-mockup.c
+wget https://git.launchpad.net/~canonical-kernel/ubuntu/+source/linux-azure/+git/jammy/plain/drivers/gpio/gpiolib.h
 
 # Create Makefile
 echo "
@@ -45,4 +39,3 @@ gpio_mock_chip=$(ls /dev/gpiochip* | sort -n | head -n 1)
 echo "GPIO Mockup chip: $gpio_mock_chip"
 
 cd ..
-


### PR DESCRIPTION
## Summary
Fix GPIO Simulation problem by using the correct linux-azure driver instead of fetching from upstream. 

* Updated gpio-mock.sh script to fetch from linux-azure LP repo.
