### PR TITLE
Dump thread test logs even if failed

### DIFF
--- a/tests/snap_test.go
+++ b/tests/snap_test.go
@@ -234,6 +234,7 @@ func TestWifiMatterCommander(t *testing.T) {
 	// install chip-tool
 	err = utils.SnapInstallFromStore(t, chipToolSnap, "latest/beta")
 	t.Cleanup(func() {
+		utils.SnapDumpLogs(t, start, chipToolSnap)
 		utils.SnapRemove(t, chipToolSnap)
 	})
 	if err != nil {

--- a/tests/thread_tests/local.go
+++ b/tests/thread_tests/local.go
@@ -13,16 +13,16 @@ import (
 func setup(t *testing.T) {
 	installChipTool(t)
 
-	otbrInstallTime := time.Now()
 	// Clean
 	utils.SnapRemove(t, otbrSnap)
 
 	// Install OTBR
+	otbrInstallTime := time.Now()
 	utils.SnapInstallFromStore(t, otbrSnap, "latest/beta")
 	t.Cleanup(func() {
-		utils.SnapRemove(t, otbrSnap)
 		logs := utils.SnapLogs(t, otbrInstallTime, otbrSnap)
 		utils.WriteLogFile(t, otbrSnap, logs)
+		utils.SnapRemove(t, otbrSnap)
 	})
 
 	// Connect interfaces
@@ -67,19 +67,19 @@ func getActiveDataset(t *testing.T) string {
 
 func installChipTool(t *testing.T) {
 	const chipToolSnap = "chip-tool"
-	start := time.Now()
 
 	// clean
 	utils.SnapRemove(t, chipToolSnap)
 
+	chipToolInstallTime := time.Now()
 	require.NoError(t,
 		utils.SnapInstallFromStore(t, chipToolSnap, "latest/beta"),
 	)
 
 	t.Cleanup(func() {
-		utils.SnapRemove(t, chipToolSnap)
-		logs := utils.SnapLogs(t, start, chipToolSnap)
+		logs := utils.SnapLogs(t, chipToolInstallTime, chipToolSnap)
 		utils.WriteLogFile(t, chipToolSnap, logs)
+		utils.SnapRemove(t, chipToolSnap)
 	})
 
 	// connect interfaces

--- a/tests/thread_tests/remote.go
+++ b/tests/thread_tests/remote.go
@@ -102,8 +102,8 @@ func remote_deployOTBRAgent(t *testing.T) {
 	start := time.Now().UTC()
 
 	t.Cleanup(func() {
-		remote_exec(t, "sudo snap remove --purge openthread-border-router")
 		dumpRemoteLogs(t, "openthread-border-router", start)
+		remote_exec(t, "sudo snap remove --purge openthread-border-router")
 	})
 
 	commands := []string{
@@ -132,8 +132,8 @@ func remote_deployGPIOCommander(t *testing.T) {
 	start := time.Now().UTC()
 
 	t.Cleanup(func() {
-		remote_exec(t, "sudo snap remove --purge matter-pi-gpio-commander")
 		dumpRemoteLogs(t, "matter-pi-gpio-commander", start)
+		remote_exec(t, "sudo snap remove --purge matter-pi-gpio-commander")
 	})
 
 	installCommand := "sudo snap install matter-pi-gpio-commander --channel=latest/edge"

--- a/tests/thread_tests/remote.go
+++ b/tests/thread_tests/remote.go
@@ -103,7 +103,7 @@ func remote_deployOTBRAgent(t *testing.T) {
 
 	t.Cleanup(func() {
 		remote_exec(t, "sudo snap remove --purge openthread-border-router")
-		remoteDumpLogs(t, "openthread-border-router", start)
+		dumpRemoteLogs(t, "openthread-border-router", start)
 	})
 
 	commands := []string{
@@ -133,7 +133,7 @@ func remote_deployGPIOCommander(t *testing.T) {
 
 	t.Cleanup(func() {
 		remote_exec(t, "sudo snap remove --purge matter-pi-gpio-commander")
-		remoteDumpLogs(t, "matter-pi-gpio-commander", start)
+		dumpRemoteLogs(t, "matter-pi-gpio-commander", start)
 	})
 
 	installCommand := "sudo snap install matter-pi-gpio-commander --channel=latest/edge"
@@ -219,7 +219,7 @@ func remote_waitForLogMessage(t *testing.T, snap string, expectedLog string, sta
 	t.FailNow()
 }
 
-func remoteDumpLogs(t *testing.T, label string, start time.Time) error {
+func dumpRemoteLogs(t *testing.T, label string, start time.Time) error {
 	command := fmt.Sprintf("sudo journalctl --utc --since \"%s\" --no-pager | grep \"%s\"|| true", start.UTC().Format("2006-01-02 15:04:05"), label)
 	logs := remote_exec(t, command)
 	return utils.WriteLogFile(t, "remote-"+label, logs)

--- a/tests/thread_tests/remote.go
+++ b/tests/thread_tests/remote.go
@@ -99,12 +99,12 @@ func connectSSH(t *testing.T) {
 }
 
 func remote_deployOTBRAgent(t *testing.T) {
+	start := time.Now().UTC()
 
 	t.Cleanup(func() {
 		remote_exec(t, "sudo snap remove --purge openthread-border-router")
+		remoteDumpLogs(t, "openthread-border-router", start)
 	})
-
-	start := time.Now().UTC()
 
 	commands := []string{
 		"sudo snap remove --purge openthread-border-router",
@@ -129,9 +129,11 @@ func remote_deployOTBRAgent(t *testing.T) {
 }
 
 func remote_deployGPIOCommander(t *testing.T) {
+	start := time.Now().UTC()
 
 	t.Cleanup(func() {
 		remote_exec(t, "sudo snap remove --purge matter-pi-gpio-commander")
+		remoteDumpLogs(t, "matter-pi-gpio-commander", start)
 	})
 
 	installCommand := "sudo snap install matter-pi-gpio-commander --channel=latest/edge"
@@ -140,8 +142,6 @@ func remote_deployGPIOCommander(t *testing.T) {
 		installCommand = fmt.Sprintf("sudo snap install --dangerous %s", remoteSnapPath)
 		extraInterface = "sudo snap connect matter-pi-gpio-commander:custom-gpio matter-pi-gpio-commander:custom-gpio-dev"
 	}
-
-	start := time.Now().UTC()
 
 	commands := []string{
 		"sudo snap remove --purge matter-pi-gpio-commander",
@@ -222,5 +222,5 @@ func remote_waitForLogMessage(t *testing.T, snap string, expectedLog string, sta
 func remoteDumpLogs(t *testing.T, label string, start time.Time) error {
 	command := fmt.Sprintf("sudo journalctl --utc --since \"%s\" --no-pager | grep \"%s\"|| true", start.UTC().Format("2006-01-02 15:04:05"), label)
 	logs := remote_exec(t, command)
-	return utils.WriteLogFile(t, label, logs)
+	return utils.WriteLogFile(t, "remote-"+label, logs)
 }

--- a/tests/thread_tests/thread_test.go
+++ b/tests/thread_tests/thread_test.go
@@ -33,6 +33,4 @@ func TestThread(t *testing.T) {
 		stdout, _, _ := utils.Exec(t, "sudo chip-tool onoff off 110 1 2>&1")
 		assert.NoError(t, utils.WriteLogFile(t, "chip-tool", stdout))
 	})
-
-	assert.NoError(t, remoteDumpLogs(t, "matter-pi-gpio-commander", start))
 }


### PR DESCRIPTION
## Summary

Bring this test in line with https://github.com/canonical/chip-tool-snap/pull/78

Thread test logs are dumped during cleanup, after uninstalling the snap, even if tests failed.

## Testing Steps
<!-- Steps to test the changes. Remove if not relevant -->

<!-- Reminders:
 - Incremented the snap version
 - Added or updated tests
 - Updated the CI/CD pipelines
 - Updated the README(s)
 - Updated external documentation
-->
