### PR TITLE
Fix CI test after upstream log output change

### DIFF
--- a/tests/snap_test.go
+++ b/tests/snap_test.go
@@ -254,7 +254,7 @@ func TestWifiMatterCommander(t *testing.T) {
 		stdout, _, err = utils.Exec(t, "sudo chip-tool pairing onnetwork 110 20202021 2>&1")
 		assert.NoError(t, utils.WriteLogFile(t, chipToolSnap, stdout))
 		assert.NoError(t, err)
-		assert.Contains(t, stdout, "CHIP:IN: TransportMgr initialized")
+		assert.Contains(t, stdout, "[IN] TransportMgr initialized")
 	})
 
 	t.Run("Control", func(t *testing.T) {


### PR DESCRIPTION
## Summary
<!-- PR description, link to related documents and PRs -->
The log output of Chip Tool changed. The substring we are scanning for to detect a successful commissioning now has a different prefix. This PR updates the prefix to the correct one for the standard tests. This however still needs to be fixed for the Thread tests. See #87.

## Related issues
<!-- Add issues in bullets. Use Github keywords to link the PR to issues -->

## Testing steps
<!-- Steps to test the changes -->
Check if CI passed.
