### PR TITLE
Use self hosted arm64 runners

### DIFF
--- a/.github/workflows/build-and-test-snap.yml
+++ b/.github/workflows/build-and-test-snap.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build-arm64:
-    runs-on: ubuntu-24.04-arm
+    runs-on: [self-hosted, ARM64, Linux]
     outputs:
       snap: ${{ steps.snapcraft.outputs.snap }}
     steps:
@@ -36,7 +36,7 @@ jobs:
   publish-edge-arm64:
     # Only publish if we are on the main branch
     if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ARM64, Linux]
     needs: build-arm64
     steps:
       - name: Download locally built snap
@@ -52,7 +52,7 @@ jobs:
           release: latest/edge
 
   test-arm64:
-    runs-on: ubuntu-24.04-arm
+    runs-on: [self-hosted, ARM64, Linux]
     needs: build-arm64
     steps:
       - name: Checkout code
@@ -87,7 +87,7 @@ jobs:
   promote-beta-arm64:
     # Only promote if we are on the main branch
     if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ARM64, Linux]
     needs: [build-arm64, test-arm64]
     steps:
       - name: Install Snapcraft


### PR DESCRIPTION
## Summary
<!-- PR description, link to related documents and PRs -->
The self hosted runners are cheaper and faster. We should ideally use them.

> Warning
> The workflow fails when running on self hosted runners.

```
2024/12/13 06:52:01 Removing installed snap: false
2024/12/13 06:52:01 Failed to setup tests: failed to get mock gpio chip number: failed to get mock gpio chip number, Error ls: cannot access '/dev/gpiochip*': No such file or directory
: %!s(<nil>)
exit status 1
FAIL	matter-pi-gpio-commander-tests	32.368s
```

## Related issues
<!-- Add issues in bullets. Use Github keywords to link the PR to issues -->

## Testing steps
<!-- Steps to test the changes -->

<!-- Reminders:
 - Remove empty sections
 - Increment the version
 - Add/update tests
 - Update CI/CD pipelines
 - Update README(s)
 - Update external docs
-->
