### PR TITLE
ci: Use GitHub arm runners instead of self-hosted

### DIFF
--- a/.github/workflows/build-and-test-snap.yml
+++ b/.github/workflows/build-and-test-snap.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build-arm64:
-    runs-on: Ubuntu_ARM64_4C_16G_01
+    runs-on: ubuntu-24.04-arm
     outputs:
       snap: ${{ steps.snapcraft.outputs.snap }}
     steps:
@@ -52,7 +52,7 @@ jobs:
           release: latest/edge
 
   test-arm64:
-    runs-on: Ubuntu_ARM64_4C_16G_01
+    runs-on: ubuntu-24.04-arm
     needs: build-arm64
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary  

The current GPIO mockup script is designed to work with Linux-Azure kernels (as the [driver is sourced from the Azure kernel repository](https://github.com/canonical/matter-pi-gpio-commander/blob/68a28dcf48f659daa0614a2ad3bde29b4cd0f3ce/tests/gpio-mock.sh#L22-L23)):
https://github.com/canonical/matter-pi-gpio-commander/blob/68a28dcf48f659daa0614a2ad3bde29b4cd0f3ce/tests/gpio-mock.sh#L22-L23 and not necessarily with the standard Ubuntu kernels. This discrepancy explains why using self-hosted runners results in errors (due to driver incompatibility), whereas the script works correctly when using GitHub-hosted runners.  

Now that [GitHub ARM runners are freely available](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/), I don't see a good reason on why not to use them.  

> [!NOTE] 
> An alternative solution, if there is still a preference for using self-hosted runners, would be to update the source of the driver code to a compatible one.  

## Related issues
- Fixes:  https://github.com/canonical/matter-pi-gpio-commander/issues/91

## Testing steps
CI is updated.

<!-- Reminders:
 - Remove empty sections
 - Increment the version
 - Add/update tests
 - Update CI/CD pipelines
 - Update README(s)
 - Update external docs
-->
