### PR TITLE
fix: LightingApp build by dropping outdated header

### DIFF
--- a/app/linux/LightingAppCommandDelegate.cpp
+++ b/app/linux/LightingAppCommandDelegate.cpp
@@ -28,7 +28,6 @@
 #include <app/clusters/software-diagnostics-server/software-diagnostics-server.h>
 #include <app/clusters/switch-server/switch-server.h>
 #include <app/server/Server.h>
-#include <app/util/att-storage.h>
 #include <app/util/attribute-storage.h>
 #include <platform/PlatformManager.h>
 


### PR DESCRIPTION
## Summary

- Header was dropped on this PR: https://github.com/project-chip/connectedhomeip/pull/37618

## Related issues
- FIxes: https://github.com/canonical/matter-pi-gpio-commander/issues/94

## Testing steps
<!-- Steps to test the changes -->

<!-- Reminders:
 - Remove empty sections
 - Increment the version
 - Add/update tests
 - Update CI/CD pipelines
 - Update README(s)
 - Update external docs
-->
