### PR TITLE
Test unmodified snap from store

### DIFF
--- a/.github/workflows/build-and-test-snap.yml
+++ b/.github/workflows/build-and-test-snap.yml
@@ -14,6 +14,9 @@ concurrency:
   group: snap-ci
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 env:
   ARTIFACT_ARM64: matter-pi-gpio-commander_${{ github.run_number}}_arm64
 
@@ -120,20 +123,9 @@ jobs:
         working-directory: tests
         env:
           MOCK_GPIO: true
-          SNAP_CHANNEL: ${{ needs.publish-edge-arm64.outputs.revision }}
+          SNAP_REVISION: ${{ needs.publish-edge-arm64.outputs.revision }}
           TEARDOWN: true
-        run: |
-          revision="${{ needs.publish-edge-arm64.outputs.revision }}"
-          for delay in 0 10 30 60; do
-            sleep "$delay"
-            if snap info matter-pi-gpio-commander |
-              grep -Eq "^[[:space:]]+latest/edge:.*[[:space:]]${revision}[[:space:]]"; then
-              go test -failfast -p 1 -timeout 20m -v
-              exit
-            fi
-          done
-          echo "Store revision $revision did not become available on latest/edge" >&2
-          exit 1
+        run: go test -failfast -p 1 -timeout 20m -v
 
       - name: Upload snap logs
         if: always()

--- a/.github/workflows/build-and-test-snap.yml
+++ b/.github/workflows/build-and-test-snap.yml
@@ -42,20 +42,34 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: build-arm64
+    outputs:
+      revision: ${{ steps.publish.outputs.revision }}
     steps:
       - name: Download locally built snap
         uses: actions/download-artifact@v8
         with:
           name: ${{ env.ARTIFACT_ARM64 }}
 
-      - uses: snapcore/action-publish@v1
+      - name: Install Snapcraft
+        run: sudo snap install snapcraft --classic
+
+      - name: Publish exact revision to edge
+        id: publish
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-        with:
-          snap: ${{ needs.build-arm64.outputs.snap }}
-          release: latest/edge
+          SNAP_FILE: ${{ needs.build-arm64.outputs.snap }}
+        run: |
+          set -euo pipefail
+          output=$(snapcraft upload "$SNAP_FILE" --release latest/edge 2>&1 | tee /dev/stderr)
+          revision=$(sed -nE 's/^Revision ([0-9]+) .*/\1/p' <<<"$output" | tail -n 1)
+          if [[ ! "$revision" =~ ^[0-9]+$ ]]; then
+            echo "Could not determine the uploaded Store revision" >&2
+            exit 1
+          fi
+          echo "revision=$revision" >> "$GITHUB_OUTPUT"
 
   test-arm64:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04-arm
     needs: build-arm64
     steps:
@@ -77,7 +91,7 @@ jobs:
         working-directory: tests
         env:
           MOCK_GPIO: true
-          TEARDOWN: false
+          TEARDOWN: true
           SNAP_PATH: ../${{ needs.build-arm64.outputs.snap }}
         run: go test -failfast -p 1 -timeout 20m -v
 
@@ -88,21 +102,62 @@ jobs:
           name: snap-logs
           path: tests/logs/*.log
 
+  test-published-arm64:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04-arm
+    needs: [build-arm64, publish-edge-arm64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: "1.*"
+          cache: false
+
+      - name: Test published Store revision
+        working-directory: tests
+        env:
+          MOCK_GPIO: true
+          SNAP_CHANNEL: ${{ needs.publish-edge-arm64.outputs.revision }}
+          TEARDOWN: true
+        run: |
+          revision="${{ needs.publish-edge-arm64.outputs.revision }}"
+          for delay in 0 10 30 60; do
+            sleep "$delay"
+            if snap info matter-pi-gpio-commander |
+              grep -Eq "^[[:space:]]+latest/edge:.*[[:space:]]${revision}[[:space:]]"; then
+              go test -failfast -p 1 -timeout 20m -v
+              exit
+            fi
+          done
+          echo "Store revision $revision did not become available on latest/edge" >&2
+          exit 1
+
+      - name: Upload snap logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: published-snap-logs-arm64
+          path: tests/logs/*.log
+          if-no-files-found: warn
+
   promote-beta-arm64:
     # Only promote if we are on the main branch
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: [build-arm64, publish-edge-arm64, test-arm64]
+    needs: [publish-edge-arm64, test-published-arm64]
     steps:
       - name: Install Snapcraft
         run: |
           sudo snap install snapcraft --classic
         shell: bash
 
-      - name: Promote to beta
+      - name: Release tested revision to beta
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         run: |
-          snapcraft promote matter-pi-gpio-commander --yes \
-            --from-channel latest/edge \
-            --to-channel latest/beta
+          snapcraft release matter-pi-gpio-commander \
+            "${{ needs.publish-edge-arm64.outputs.revision }}" \
+            latest/beta

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,7 +10,7 @@ The machine should be a compatible Raspberry Pi, unless the GPIO is mocked.
 
 To run the tests, you must set the following environment variables:
 
-- `SNAP_CHANNEL`: The channel from which the snap will be downloaded. The default value is `latest/edge`. This is ignored when using a locally built snap.
+- `SNAP_REVISION`: The numeric Store revision of the snap to test. This is required unless `SNAP_PATH` is set.
 - `SNAP_PATH`: Path to the local snap to be tested instead of downloading from the store.
 - `TEARDOWN`: Remove snaps after tests. Useful to disable when running on CI machines. The default value is `true`.
 - `MOCK_GPIO`: Use a kernel `gpio-sim` device instead of a physical gpiochip. The default value is `false`. The simulated chip must be assigned number 0 or 4 so the test can use the Store snap's existing `custom-gpio-dev` slot without modifying the application snap.

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,7 +13,7 @@ To run the tests, you must set the following environment variables:
 - `SNAP_CHANNEL`: The channel from which the snap will be downloaded. The default value is `latest/edge`. This is ignored when using a locally built snap.
 - `SNAP_PATH`: Path to the local snap to be tested instead of downloading from the store.
 - `TEARDOWN`: Remove snaps after tests. Useful to disable when running on CI machines. The default value is `true`.
-- `MOCK_GPIO`: Use gpio-mock to test the application instead of a physical gpiochip. The default value is `false`. The GPIO mocking logic works by modifying a local snap; the path to which must be set in `SNAP_PATH`.
+- `MOCK_GPIO`: Use a kernel `gpio-sim` device instead of a physical gpiochip. The default value is `false`. The simulated chip must be assigned number 0 or 4 so the test can use the Store snap's existing `custom-gpio-dev` slot without modifying the application snap.
 - `GPIO_CHIP`: The GPIO chip number; accepted values are `0` (for legacy Raspberry Pis) or `4` for the Raspberry Pi 5. This is ignored when mocking GPIO.
 - `GPIO_LINE`: This is the line offset to be used to test the selected gpiochip. The number of available lines can be checked with the `gpiodetect` and `gpioinfo` commands from the Debian package `gpiod`. This is ignored when mocking GPIO.
 

--- a/tests/gpio-mock.sh
+++ b/tests/gpio-mock.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 gpio_sim_device=/sys/kernel/config/gpio-sim/matter-pi-gpio
 state_file=/tmp/matter-pi-gpio-sim-chip
+sysfs_path_file=/tmp/matter-pi-gpio-sim-sysfs
 
 teardown() {
   if [ -d "$gpio_sim_device" ]; then
@@ -12,7 +13,7 @@ teardown() {
   fi
 
   sudo modprobe -r gpio-sim >/dev/null 2>&1 || true
-  rm -f "$state_file"
+  rm -f "$state_file" "$sysfs_path_file"
 }
 
 if [ "${1:-}" = "teardown" ]; then
@@ -21,34 +22,19 @@ if [ "${1:-}" = "teardown" ]; then
 fi
 
 if [ "${1:-}" = "state" ]; then
-  chip_number="${2:?GPIO chip number is required}"
-  line_offset="${3:?GPIO line offset is required}"
+  line_offset="${2:?GPIO line offset is required}"
+  gpio_sysfs_path=$(cat "$sysfs_path_file")
+  value=$(cat "$gpio_sysfs_path/sim_gpio${line_offset}/value")
 
-  if ! mountpoint -q /sys/kernel/debug; then
-    sudo mount -t debugfs debugfs /sys/kernel/debug
-  fi
-
-  sudo awk -v chip="gpiochip${chip_number}:" -v offset="$line_offset" '
-    $1 == chip {
-      in_chip = 1
-      base = 0
-      if ($2 == "GPIOs") {
-        split($3, range, "-")
-        base = range[1]
-      }
-      gpio = "gpio-" (base + offset)
-      next
-    }
-    in_chip && /^gpiochip/ { exit 1 }
-    in_chip && $1 == gpio && $0 ~ /(output-high|out hi)(,| |$)/ {
-      print "high"; found = 1; exit
-    }
-    in_chip && $1 == gpio && $0 ~ /(output-low|out lo)(,| |$)/ {
-      print "low"; found = 1; exit
-    }
-    END { if (!found) exit 1 }
-  ' /sys/kernel/debug/gpio
-  exit 0
+  case "$value" in
+    0) echo "low" ;;
+    1) echo "high" ;;
+    *)
+      echo "Unexpected GPIO value: $value" >&2
+      exit 1
+      ;;
+  esac
+  exit
 fi
 
 teardown
@@ -100,10 +86,7 @@ if [ ! -e "$gpio_class_path" ]; then
 fi
 gpio_sysfs_path=$(readlink -f "$gpio_class_path")
 echo "$gpio_chip_number" > "$state_file"
-
-if ! mountpoint -q /sys/kernel/debug; then
-  sudo mount -t debugfs debugfs /sys/kernel/debug
-fi
+echo "$gpio_sysfs_path" > "$sysfs_path_file"
 
 echo "GPIO simulator chip: /dev/$gpio_mock_chip"
 echo "GPIO simulator sysfs path: $gpio_sysfs_path"

--- a/tests/gpio-mock.sh
+++ b/tests/gpio-mock.sh
@@ -28,24 +28,24 @@ if [ "${1:-}" = "state" ]; then
     sudo mount -t debugfs debugfs /sys/kernel/debug
   fi
 
-  gpio_base=$(
-    sudo awk -v chip="gpiochip${chip_number}:" '
-      $1 == chip {
+  sudo awk -v chip="gpiochip${chip_number}:" -v offset="$line_offset" '
+    $1 == chip {
+      in_chip = 1
+      base = 0
+      if ($2 == "GPIOs") {
         split($3, range, "-")
-        print range[1]
-        exit
+        base = range[1]
       }
-    ' /sys/kernel/debug/gpio
-  )
-  if [ -z "$gpio_base" ]; then
-    echo "unknown"
-    exit 1
-  fi
-
-  gpio_number=$((gpio_base + line_offset))
-  sudo awk -v gpio="gpio-${gpio_number}" '
-    $1 == gpio && $0 ~ / out hi( |$)/ { print "high"; found = 1; exit }
-    $1 == gpio && $0 ~ / out lo( |$)/ { print "low"; found = 1; exit }
+      gpio = "gpio-" (base + offset)
+      next
+    }
+    in_chip && /^gpiochip/ { exit 1 }
+    in_chip && $1 == gpio && $0 ~ /(output-high|out hi)(,| |$)/ {
+      print "high"; found = 1; exit
+    }
+    in_chip && $1 == gpio && $0 ~ /(output-low|out lo)(,| |$)/ {
+      print "low"; found = 1; exit
+    }
     END { if (!found) exit 1 }
   ' /sys/kernel/debug/gpio
   exit 0
@@ -53,8 +53,10 @@ fi
 
 teardown
 
-sudo apt-get update
-sudo apt-get install -y "linux-modules-extra-$(uname -r)"
+if ! modinfo gpio-sim >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y "linux-modules-extra-$(uname -r)"
+fi
 
 echo "Kernel version: $(uname -r)"
 
@@ -69,28 +71,34 @@ sudo mkdir "$gpio_sim_device/bank0"
 echo 16 | sudo tee "$gpio_sim_device/bank0/num_lines" >/dev/null
 echo 1 | sudo tee "$gpio_sim_device/live" >/dev/null
 
-gpio_mock_chip=$(
-  find /sys/class/gpio -maxdepth 1 -type l -name 'gpiochip*' -printf '%f\n' |
-    while read -r chip; do
-      if readlink -f "/sys/class/gpio/$chip" | grep -q '/gpio-sim\.'; then
-        echo "$chip"
-      fi
-    done |
-    sort -V |
-    tail -n 1
-)
-if [ -z "$gpio_mock_chip" ]; then
+actual_gpio_mock_chip=$(cat "$gpio_sim_device/bank0/chip_name")
+if [ -z "$actual_gpio_mock_chip" ]; then
   echo "Failed to find the gpio-sim chip" >&2
   exit 1
 fi
 
-gpio_chip_number=${gpio_mock_chip#gpiochip}
+for _ in $(seq 1 50); do
+  [ -e "/dev/$actual_gpio_mock_chip" ] && break
+  sleep 0.1
+done
+if [ ! -e "/dev/$actual_gpio_mock_chip" ]; then
+  echo "Device node /dev/$actual_gpio_mock_chip was not created" >&2
+  exit 1
+fi
+
+actual_gpio_chip_number=${actual_gpio_mock_chip#gpiochip}
+gpio_mock_chip=$actual_gpio_mock_chip
+gpio_chip_number=$actual_gpio_chip_number
 if [ "$gpio_chip_number" != "0" ] && [ "$gpio_chip_number" != "4" ]; then
   echo "gpio-sim created /dev/$gpio_mock_chip; the snap only permits gpiochip0 or gpiochip4" >&2
   exit 1
 fi
 
-gpio_sysfs_path=$(readlink -f "/sys/class/gpio/$gpio_mock_chip")
+gpio_class_path="/sys/class/gpio/${actual_gpio_mock_chip/gpiochip/chip}"
+if [ ! -e "$gpio_class_path" ]; then
+  gpio_class_path="/sys/class/gpio/$actual_gpio_mock_chip"
+fi
+gpio_sysfs_path=$(readlink -f "$gpio_class_path")
 echo "$gpio_chip_number" > "$state_file"
 
 if ! mountpoint -q /sys/kernel/debug; then

--- a/tests/gpio-mock.sh
+++ b/tests/gpio-mock.sh
@@ -3,20 +3,65 @@
 set -euo pipefail
 
 gpio_sim_device=/sys/kernel/config/gpio-sim/matter-pi-gpio
+state_file=/tmp/matter-pi-gpio-sim-chip
 
-if [ "${1:-}" = "teardown" ]; then
+teardown() {
   if [ -d "$gpio_sim_device" ]; then
     echo 0 | sudo tee "$gpio_sim_device/live" >/dev/null
     sudo rmdir "$gpio_sim_device/bank0" "$gpio_sim_device"
   fi
-  sudo modprobe -r gpio-sim
+
+  sudo modprobe -r gpio-sim >/dev/null 2>&1 || true
+  rm -f "$state_file"
+}
+
+if [ "${1:-}" = "teardown" ]; then
+  teardown
   exit 0
 fi
+
+if [ "${1:-}" = "state" ]; then
+  chip_number="${2:?GPIO chip number is required}"
+  line_offset="${3:?GPIO line offset is required}"
+
+  if ! mountpoint -q /sys/kernel/debug; then
+    sudo mount -t debugfs debugfs /sys/kernel/debug
+  fi
+
+  gpio_base=$(
+    sudo awk -v chip="gpiochip${chip_number}:" '
+      $1 == chip {
+        split($3, range, "-")
+        print range[1]
+        exit
+      }
+    ' /sys/kernel/debug/gpio
+  )
+  if [ -z "$gpio_base" ]; then
+    echo "unknown"
+    exit 1
+  fi
+
+  gpio_number=$((gpio_base + line_offset))
+  sudo awk -v gpio="gpio-${gpio_number}" '
+    $1 == gpio && $0 ~ / out hi( |$)/ { print "high"; found = 1; exit }
+    $1 == gpio && $0 ~ / out lo( |$)/ { print "low"; found = 1; exit }
+    END { if (!found) exit 1 }
+  ' /sys/kernel/debug/gpio
+  exit 0
+fi
+
+teardown
 
 sudo apt-get update
 sudo apt-get install -y "linux-modules-extra-$(uname -r)"
 
 echo "Kernel version: $(uname -r)"
+
+sudo modprobe configfs
+if ! mountpoint -q /sys/kernel/config; then
+  sudo mount -t configfs configfs /sys/kernel/config
+fi
 
 sudo modprobe gpio-sim
 sudo mkdir "$gpio_sim_device"
@@ -24,6 +69,33 @@ sudo mkdir "$gpio_sim_device/bank0"
 echo 16 | sudo tee "$gpio_sim_device/bank0/num_lines" >/dev/null
 echo 1 | sudo tee "$gpio_sim_device/live" >/dev/null
 
-gpio_mock_chip=$(ls /dev/gpiochip* | sort -n | head -n 1)
+gpio_mock_chip=$(
+  find /sys/class/gpio -maxdepth 1 -type l -name 'gpiochip*' -printf '%f\n' |
+    while read -r chip; do
+      if readlink -f "/sys/class/gpio/$chip" | grep -q '/gpio-sim\.'; then
+        echo "$chip"
+      fi
+    done |
+    sort -V |
+    tail -n 1
+)
+if [ -z "$gpio_mock_chip" ]; then
+  echo "Failed to find the gpio-sim chip" >&2
+  exit 1
+fi
 
-echo "GPIO Mockup chip: $gpio_mock_chip"
+gpio_chip_number=${gpio_mock_chip#gpiochip}
+if [ "$gpio_chip_number" != "0" ] && [ "$gpio_chip_number" != "4" ]; then
+  echo "gpio-sim created /dev/$gpio_mock_chip; the snap only permits gpiochip0 or gpiochip4" >&2
+  exit 1
+fi
+
+gpio_sysfs_path=$(readlink -f "/sys/class/gpio/$gpio_mock_chip")
+echo "$gpio_chip_number" > "$state_file"
+
+if ! mountpoint -q /sys/kernel/debug; then
+  sudo mount -t debugfs debugfs /sys/kernel/debug
+fi
+
+echo "GPIO simulator chip: /dev/$gpio_mock_chip"
+echo "GPIO simulator sysfs path: $gpio_sysfs_path"

--- a/tests/snap_test.go
+++ b/tests/snap_test.go
@@ -162,7 +162,7 @@ func setupGPIO() error {
 
 func gpioState() (string, error) {
 	stdout, stderr, err := utils.Exec(nil,
-		fmt.Sprintf("./gpio-mock.sh state %s %s", gpioChip, gpioLine))
+		fmt.Sprintf("./gpio-mock.sh state %s", gpioLine))
 	if err != nil {
 		return "", fmt.Errorf("read simulated GPIO state: %w: %s", err, stderr)
 	}

--- a/tests/snap_test.go
+++ b/tests/snap_test.go
@@ -181,7 +181,7 @@ func TestConfigurationValidation(t *testing.T) {
 		t.Skip("configuration restoration requires the simulated GPIO")
 	}
 
-	_, _, err := utils.Exec(t, "sudo snap set "+snapMatterPiGPIO+" gpio=0")
+	_, _, err := utils.Exec(nil, "sudo snap set "+snapMatterPiGPIO+" gpio=0")
 	assert.Error(t, err)
 
 	stdout, _, err := utils.Exec(t, "snap get "+snapMatterPiGPIO+" gpio")
@@ -190,7 +190,7 @@ func TestConfigurationValidation(t *testing.T) {
 
 	utils.SnapSet(t, snapMatterPiGPIO, "gpiochip", "0")
 	utils.SnapSet(t, snapMatterPiGPIO, "gpiochip-validation", "true")
-	_, _, err = utils.Exec(t, "sudo snap set "+snapMatterPiGPIO+" gpiochip=7")
+	_, _, err = utils.Exec(nil, "sudo snap set "+snapMatterPiGPIO+" gpiochip=7")
 	assert.Error(t, err)
 
 	utils.SnapSet(t, snapMatterPiGPIO, "gpiochip-validation", "false")
@@ -200,7 +200,7 @@ func TestConfigurationValidation(t *testing.T) {
 func TestPackagingAndInstallBehavior(t *testing.T) {
 	stdout, _, err := utils.Exec(t, "snap info --verbose "+snapMatterPiGPIO)
 	assert.NoError(t, err)
-	assert.Contains(t, stdout, "confinement: strict")
+	assert.Regexp(t, `(?m)^\s*confinement:\s+strict\s*$`, stdout)
 
 	stdout, _, err = utils.Exec(t, "sudo snap run "+snapMatterPiGPIO+".help")
 	assert.NoError(t, err)
@@ -216,7 +216,7 @@ func TestInvalidGPIOLine(t *testing.T) {
 	}
 
 	utils.SnapSet(t, snapMatterPiGPIO, "gpio", "99")
-	stdout, _, err := utils.Exec(t, "sudo snap run "+snapMatterPiGPIO+".test-blink 2>&1")
+	stdout, _, err := utils.Exec(nil, "sudo snap run "+snapMatterPiGPIO+".test-blink 2>&1")
 	assert.Error(t, err)
 	assert.Contains(t, stdout, "Failed to request output line")
 	utils.SnapSet(t, snapMatterPiGPIO, "gpio", gpioLine)
@@ -232,12 +232,12 @@ func TestBlinkOperation(t *testing.T) {
 		t.Skip("GPIO state assertions require the simulator")
 	}
 
-	_, _, err := utils.Exec(t, "sudo snap disconnect "+
+	_, _, err := utils.Exec(nil, "sudo snap disconnect "+
 		snapMatterPiGPIO+":custom-gpio "+
 		snapMatterPiGPIO+":custom-gpio-dev")
 	assert.NoError(t, err)
 
-	stdout, _, err := utils.Exec(t,
+	stdout, _, err := utils.Exec(nil,
 		"sudo timeout 5s snap run "+snapMatterPiGPIO+".test-blink 2>&1")
 	assert.Error(t, err)
 	assert.Contains(t, stdout, "Failed to request output line")
@@ -264,8 +264,8 @@ func TestBlinkOperation(t *testing.T) {
 		return seen["high"] && seen["low"]
 	}, 4*time.Second, 50*time.Millisecond)
 	cancel()
-	_ = command.Wait()
 	stopBlink(t)
+	_ = command.Wait()
 
 	stdout = output.String()
 	assert.NoError(t, utils.WriteLogFile(t, snapMatterPiGPIO, stdout))

--- a/tests/snap_test.go
+++ b/tests/snap_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -21,6 +22,7 @@ const (
 	specificGpioChip = "GPIO_CHIP"
 	specificGpioLine = "GPIO_LINE"
 	gpioChipMock     = "MOCK_GPIO"
+	snapRevision     = "SNAP_REVISION"
 )
 
 const snapMatterPiGPIO = "matter-pi-gpio-commander"
@@ -62,7 +64,7 @@ func setup() (teardown func(), err error) {
 	if env.SnapPath() != "" {
 		err = utils.SnapInstallFromFile(nil, env.SnapPath())
 	} else {
-		err = utils.SnapInstallFromStore(nil, snapMatterPiGPIO, env.SnapChannel())
+		err = installSnapRevision(snapMatterPiGPIO, os.Getenv(snapRevision))
 	}
 	if err != nil {
 		teardown()
@@ -102,6 +104,27 @@ func setup() (teardown func(), err error) {
 	}
 
 	return
+}
+
+func installSnapRevision(name, revision string) error {
+	if _, err := strconv.ParseUint(revision, 10, 64); err != nil {
+		return fmt.Errorf("%s must be a numeric Store revision: %q", snapRevision, revision)
+	}
+
+	var lastErr error
+	for _, delay := range []time.Duration{0, 10 * time.Second, 30 * time.Second, 60 * time.Second} {
+		time.Sleep(delay)
+
+		output, err := exec.Command(
+			"sudo", "snap", "install", name, "--revision="+revision,
+		).CombinedOutput()
+		if err == nil {
+			return nil
+		}
+		lastErr = fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
+	}
+
+	return fmt.Errorf("install %s revision %s: %w", name, revision, lastErr)
 }
 
 func useGPIOMock() bool {
@@ -184,7 +207,7 @@ func TestConfigurationValidation(t *testing.T) {
 	_, _, err := utils.Exec(nil, "sudo snap set "+snapMatterPiGPIO+" gpio=0")
 	assert.Error(t, err)
 
-	stdout, _, err := utils.Exec(t, "snap get "+snapMatterPiGPIO+" gpio")
+	stdout, _, err := utils.Exec(t, "sudo snap get "+snapMatterPiGPIO+" gpio")
 	assert.NoError(t, err)
 	assert.Equal(t, gpioLine, strings.TrimSpace(stdout))
 

--- a/tests/snap_test.go
+++ b/tests/snap_test.go
@@ -1,11 +1,12 @@
 package tests
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -41,8 +42,6 @@ func TestMain(m *testing.M) {
 }
 
 func setup() (teardown func(), err error) {
-	var newSnapPath string
-
 	log.Println("[CLEAN]")
 	utils.SnapRemove(nil, snapMatterPiGPIO)
 	utils.SnapRemove(nil, chipToolSnap)
@@ -52,8 +51,6 @@ func setup() (teardown func(), err error) {
 	teardown = func() {
 		log.Println("[TEARDOWN]")
 
-		utils.Exec(nil, "rm "+newSnapPath)
-
 		log.Println("Removing installed snap:", env.Teardown())
 		if env.Teardown() {
 			utils.SnapRemove(nil, snapMatterPiGPIO)
@@ -61,26 +58,42 @@ func setup() (teardown func(), err error) {
 		}
 	}
 
-	// setup gpio mock
-	if newSnapPath, err = setupGPIOMock(env.SnapPath()); err != nil {
-		teardown()
-		return
-	}
-
 	// install matter-pi-gpio-commander
 	if env.SnapPath() != "" {
-		err = utils.SnapInstallFromFile(nil, newSnapPath)
-		utils.SnapConnect(nil, snapMatterPiGPIO+":custom-gpio", snapMatterPiGPIO+":custom-gpio-dev")
+		err = utils.SnapInstallFromFile(nil, env.SnapPath())
 	} else {
 		err = utils.SnapInstallFromStore(nil, snapMatterPiGPIO, env.SnapChannel())
 	}
-
-	utils.SnapConnect(nil, snapMatterPiGPIO+":avahi-control", "")
-	utils.SnapConnect(nil, snapMatterPiGPIO+":bluez", "")
-
 	if err != nil {
 		teardown()
 		return
+	}
+
+	if err = utils.SnapConnect(nil, snapMatterPiGPIO+":avahi-control", ""); err != nil {
+		teardown()
+		return
+	}
+
+	if useGPIOMock() {
+		stdout, _, mockErr := utils.Exec(nil, "./gpio-mock.sh 2>&1")
+		_ = utils.WriteLogFile(nil, "gpio-mock", stdout)
+		if mockErr != nil {
+			teardown()
+			return nil, fmt.Errorf("failed to set up gpio-sim: %w", mockErr)
+		}
+		if err = utils.SnapConnect(nil,
+			snapMatterPiGPIO+":custom-gpio",
+			snapMatterPiGPIO+":custom-gpio-dev"); err != nil {
+			teardown()
+			return
+		}
+	} else {
+		if err = utils.SnapConnect(nil,
+			snapMatterPiGPIO+":custom-gpio",
+			snapMatterPiGPIO+":custom-gpio-dev"); err != nil {
+			teardown()
+			return
+		}
 	}
 
 	if err = setupGPIO(); err != nil {
@@ -91,86 +104,21 @@ func setup() (teardown func(), err error) {
 	return
 }
 
-func setupGPIOMock(snapPath string) (string, error) {
-	// Check if gpio mock is enabled and a local snap is provided
-	if !useGPIOMock() || env.SnapPath() == "" {
-		return snapPath, nil
-	}
-
-	// Run gpio mockup script
-	stdout, _, err := utils.Exec(nil, "./gpio-mock.sh 2>&1")
-	_ = utils.WriteLogFile(nil, "gpio-mock", stdout)
-	if err != nil {
-		return snapPath, fmt.Errorf("failed to run gpio mockup script: %s", err)
-	}
-
-	// authorize gpio mock
-	newPath, err := authorizeGpioMock(snapPath)
-	if err != nil {
-		return snapPath, err
-	}
-
-	return newPath, nil
-}
-
 func useGPIOMock() bool {
 	return os.Getenv(gpioChipMock) == "true"
 }
 
 func getMockGPIO() (string, error) {
-	gpioChipNumber, stderr, err := utils.Exec(nil, "ls /dev/gpiochip* | sort -n | tail -n 1 | cut -d'p' -f3")
+	gpioChipNumber, stderr, err := utils.Exec(nil, "cat /tmp/matter-pi-gpio-sim-chip")
 	if err != nil || stderr != "" {
 		return "", fmt.Errorf("failed to get mock gpio chip number, Error %s: %s", stderr, err)
 	}
-	gpioChipNumber = strings.TrimSpace(gpioChipNumber)
-	gpioChipNumber = strings.Trim(gpioChipNumber, "\n")
-	return gpioChipNumber, nil
-}
-
-func authorizeGpioMock(path string) (string, error) {
-	const sedAuthorizeMockRead = `sed -i '/\/sys\/devices\/platform\/axi\/\*.pcie\/\*.gpio\/gpiochip4\/dev/a \      - /sys/devices/platform/gpio-sim.*/gpiochip*/dev' squashfs-root/meta/snap.yaml`
-	const sedAuthorizeMockGPIOsChips = `sed -i 's/gpiochip[0,4]/gpiochip\*/' squashfs-root/meta/snap.yaml `
-
-	utils.Exec(nil, "rm -rf squashfs-root")
-
-	_, stderr, err := utils.Exec(nil, "unsquashfs "+path)
-	if err != nil || stderr != "" {
-		log.Printf("stderr: %s", stderr)
-		log.Printf("err: %s", err)
-		return "", err
-	}
-
-	_, stderr, err = utils.Exec(nil, sedAuthorizeMockRead)
-	if err != nil || stderr != "" {
-		log.Printf("stderr: %s", stderr)
-		log.Printf("err: %s", err)
-		return "", err
-	}
-
-	_, stderr, err = utils.Exec(nil, sedAuthorizeMockGPIOsChips)
-	if err != nil || stderr != "" {
-		log.Printf("stderr: %s", stderr)
-		log.Printf("err: %s", err)
-		return "", err
-	}
-
-	directory := filepath.Dir(path)
-	newPath := directory + "/mod_matter-pi-gpio-commander.snap"
-	_, stderr, err = utils.Exec(nil, "mksquashfs squashfs-root "+newPath)
-	if err != nil || stderr != "" {
-		log.Printf("stderr: %s", stderr)
-		log.Printf("err: %s", err)
-		return "", err
-	}
-
-	utils.Exec(nil, "rm -rf squashfs-root")
-	return newPath, nil
+	return strings.TrimSpace(gpioChipNumber), nil
 }
 
 func setupGPIO() error {
 	var err error
-	// The GPIO_MOCKUP takes precedence over the specific GPIO_CHIP and GPIO_LINE
-	if useGPIOMock() && env.SnapPath() != "" {
+	if useGPIOMock() {
 		utils.SnapSet(nil, snapMatterPiGPIO, "gpiochip-validation", "false")
 
 		gpioChip, err = getMockGPIO()
@@ -189,32 +137,138 @@ func setupGPIO() error {
 	return nil
 }
 
+func gpioState() (string, error) {
+	stdout, stderr, err := utils.Exec(nil,
+		fmt.Sprintf("./gpio-mock.sh state %s %s", gpioChip, gpioLine))
+	if err != nil {
+		return "", fmt.Errorf("read simulated GPIO state: %w: %s", err, stderr)
+	}
+	return strings.TrimSpace(stdout), nil
+}
+
+func waitForGPIOState(t *testing.T, expected string) {
+	t.Helper()
+
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		state, err := gpioState()
+		assert.NoError(collect, err)
+		assert.Equal(collect, expected, state)
+	}, 5*time.Second, 100*time.Millisecond)
+}
+
+func runChipTool(t *testing.T, args string) string {
+	t.Helper()
+
+	stdout, _, err := utils.Exec(t, "sudo chip-tool "+args+" 2>&1")
+	assert.NoError(t, utils.WriteLogFile(t, chipToolSnap, stdout))
+	assert.NoError(t, err)
+	return stdout
+}
+
+func stopBlink(t *testing.T) {
+	t.Helper()
+
+	_, _, _ = utils.Exec(t,
+		`sudo sh -c 'for pid in $(pgrep -f "/[b]in/test-blink" || true); do kill "$pid"; done'`)
+	assert.Eventually(t, func() bool {
+		_, _, err := utils.Exec(nil, `pgrep -f "/[b]in/test-blink"`)
+		return err != nil
+	}, 5*time.Second, 100*time.Millisecond)
+}
+
+func TestConfigurationValidation(t *testing.T) {
+	if !useGPIOMock() {
+		t.Skip("configuration restoration requires the simulated GPIO")
+	}
+
+	_, _, err := utils.Exec(t, "sudo snap set "+snapMatterPiGPIO+" gpio=0")
+	assert.Error(t, err)
+
+	stdout, _, err := utils.Exec(t, "snap get "+snapMatterPiGPIO+" gpio")
+	assert.NoError(t, err)
+	assert.Equal(t, gpioLine, strings.TrimSpace(stdout))
+
+	utils.SnapSet(t, snapMatterPiGPIO, "gpiochip", "0")
+	utils.SnapSet(t, snapMatterPiGPIO, "gpiochip-validation", "true")
+	_, _, err = utils.Exec(t, "sudo snap set "+snapMatterPiGPIO+" gpiochip=7")
+	assert.Error(t, err)
+
+	utils.SnapSet(t, snapMatterPiGPIO, "gpiochip-validation", "false")
+	utils.SnapSet(t, snapMatterPiGPIO, "gpiochip", gpioChip)
+}
+
+func TestPackagingAndInstallBehavior(t *testing.T) {
+	stdout, _, err := utils.Exec(t, "snap info --verbose "+snapMatterPiGPIO)
+	assert.NoError(t, err)
+	assert.Contains(t, stdout, "confinement: strict")
+
+	stdout, _, err = utils.Exec(t, "sudo snap run "+snapMatterPiGPIO+".help")
+	assert.NoError(t, err)
+	assert.Contains(t, stdout, "Usage")
+
+	assert.False(t, utils.SnapServicesEnabled(t, snapMatterPiGPIO))
+	assert.False(t, utils.SnapServicesActive(t, snapMatterPiGPIO))
+}
+
+func TestInvalidGPIOLine(t *testing.T) {
+	if !useGPIOMock() {
+		t.Skip("runtime recovery requires the simulated GPIO")
+	}
+
+	utils.SnapSet(t, snapMatterPiGPIO, "gpio", "99")
+	stdout, _, err := utils.Exec(t, "sudo snap run "+snapMatterPiGPIO+".test-blink 2>&1")
+	assert.Error(t, err)
+	assert.Contains(t, stdout, "Failed to request output line")
+	utils.SnapSet(t, snapMatterPiGPIO, "gpio", gpioLine)
+}
+
 /*
 TestBlinkOperation runs the test-blink app in the snap.
 The log output is checked for the correctly configured GPIO Chip and GPIO Line,
 as well as the existence of the ON and OFF log messages.
 */
 func TestBlinkOperation(t *testing.T) {
-	/*
-		`test-blink` runs until it is stopped.
-		We use a context with a timeout to manually stop it after a few seconds.
-	*/
+	if !useGPIOMock() {
+		t.Skip("GPIO state assertions require the simulator")
+	}
+
+	_, _, err := utils.Exec(t, "sudo snap disconnect "+
+		snapMatterPiGPIO+":custom-gpio "+
+		snapMatterPiGPIO+":custom-gpio-dev")
+	assert.NoError(t, err)
+
+	stdout, _, err := utils.Exec(t,
+		"sudo timeout 5s snap run "+snapMatterPiGPIO+".test-blink 2>&1")
+	assert.Error(t, err)
+	assert.Contains(t, stdout, "Failed to request output line")
+	stopBlink(t)
+	assert.NoError(t, utils.SnapConnect(t,
+		snapMatterPiGPIO+":custom-gpio",
+		snapMatterPiGPIO+":custom-gpio-dev"))
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
 
-	/*
-		Context timeout does not stop the process in a GitHub runner.
-		We have to manually kill it. We do that shortly after the context should have timed out.
-		See issue https://github.com/canonical/matter-snap-testing/issues/17
-	*/
-	go func() {
-		time.Sleep(10 * time.Second)
-		utils.Exec(t, `sudo pkill -f "test-blink"`)
-	}()
+	var output bytes.Buffer
+	command := exec.CommandContext(ctx, "sudo", "snap", "run", snapMatterPiGPIO+".test-blink")
+	command.Stdout = &output
+	command.Stderr = &output
+	assert.NoError(t, command.Start())
 
-	stdout, _, err := utils.ExecContextVerbose(t, ctx, "sudo "+snapMatterPiGPIO+".test-blink")
+	seen := map[string]bool{}
+	assert.Eventually(t, func() bool {
+		state, stateErr := gpioState()
+		if stateErr == nil {
+			seen[state] = true
+		}
+		return seen["high"] && seen["low"]
+	}, 4*time.Second, 50*time.Millisecond)
+	cancel()
+	_ = command.Wait()
+	stopBlink(t)
+
+	stdout = output.String()
 	assert.NoError(t, utils.WriteLogFile(t, snapMatterPiGPIO, stdout))
-	assert.NoError(t, err)
 
 	assert.Contains(t, stdout, fmt.Sprintf("GPIO: %s", gpioLine))
 	assert.Contains(t, stdout, fmt.Sprintf("GPIOCHIP: %s", gpioChip))
@@ -258,14 +312,30 @@ func TestWifiMatterCommander(t *testing.T) {
 	})
 
 	t.Run("Control", func(t *testing.T) {
-		stdoutCombined := ""
-		for i := 0; i < 4; i++ {
-			stdout, _, err = utils.Exec(t, "sudo chip-tool onoff toggle 110 1 2>&1")
-			stdoutCombined += stdout
-			// TODO: We should be saving the logs (append to file) before exiting on error
-			assert.NoError(t, err)
-		}
-		assert.NoError(t, utils.WriteLogFile(t, chipToolSnap, stdoutCombined))
-		assert.Contains(t, stdoutCombined, "Success status report received. Session was established")
+		stdout = runChipTool(t, "onoff off 110 1")
+		assert.Contains(t, stdout, "Success status report received")
+		waitForGPIOState(t, "low")
+
+		stdout = runChipTool(t, "onoff read on-off 110 1")
+		assert.Contains(t, stdout, "OnOff")
+
+		stdout = runChipTool(t, "onoff on 110 1")
+		assert.Contains(t, stdout, "Success status report received")
+		waitForGPIOState(t, "high")
+
+		stdout = runChipTool(t, "onoff toggle 110 1")
+		assert.Contains(t, stdout, "Success status report received")
+		waitForGPIOState(t, "low")
+	})
+
+	t.Run("RestartPersistence", func(t *testing.T) {
+		utils.SnapRestart(t, snapMatterPiGPIO)
+		assert.Eventually(t, func() bool {
+			return utils.SnapServicesActive(t, snapMatterPiGPIO)
+		}, 10*time.Second, 500*time.Millisecond)
+
+		stdout = runChipTool(t, "onoff on 110 1")
+		assert.Contains(t, stdout, "Success status report received")
+		waitForGPIOState(t, "high")
 	})
 }


### PR DESCRIPTION
## Summary

Previously we used a local build of the snap, and manually changed it to support mocked GPIO. This PR changes this behaviour to test a built snap exactly as it was produced — from a local file or from the store — without modifying it after the build, using a different GPIO simulator approach.

The snap is now exercised through a kernel `gpio-sim` device, so the simulated line state itself is asserted instead of only the application output. `MOCK_GPIO=true` therefore requires a machine without real GPIO chips (a CI runner or a VM), because the unmodified `custom-gpio-dev` slot only grants access to `gpiochip0` and `gpiochip4`. On a Raspberry Pi the tests run against the real GPIO via `GPIO_CHIP`/`GPIO_LINE`, and the simulated-line assertions are skipped automatically.

Added coverage:
- configuration validation of `gpio` and `gpiochip` through the configure hook
- packaging and install behaviour (strict confinement, `install-mode: disable`)
- failure when the GPIO line does not exist, and when the `custom-gpio` interface is disconnected
- the `OnOff` attribute and the GPIO line state after each `chip-tool` command
- the light state surviving a restart of the service

## Related issues

`TestWifiMatterCommander/RestartPersistence` uncovered a bug in the application: the light turned off on every restart of the service, including the ones caused by a snap refresh, while the `OnOff` attribute kept reporting that it was on. That fix was split out into #106 and is now on `main`, so this branch is green again.

## Testing steps

CI runs the suite against the locally built snap with `MOCK_GPIO=true`. To run it manually:

```bash
cd tests

# against a simulated GPIO, on a machine without real GPIO chips
MOCK_GPIO=true go test -v -failfast -count 1

# against the real GPIO on a Raspberry Pi 4
GPIO_CHIP=0 GPIO_LINE=16 go test -v -failfast -count 1
```
